### PR TITLE
QoL: Turn off boss music for Ultros 2 location

### DIFF
--- a/event/event.py
+++ b/event/event.py
@@ -60,6 +60,17 @@ class Event():
             self.log_change(original_boss_name, boss_name)
         return pack_id
 
+    # return the boss in place of the given boss_name
+    # example
+    # get_replacement_formation("Goddess")
+    # if you fight Ultros in the Goddess location, return Ultros
+    def get_replacement_formation(self, boss_name):
+        from data.bosses import pack_name
+        replacement = self.get_boss(boss_name, False)
+        location_boss = pack_name[replacement]
+        formation_id = self.enemies.formations.get_id(location_boss)
+        return self.enemies.formations.formations[formation_id]
+
     def log_reward(self, reward, prefix = "", suffix = ""):
         reward_string = prefix
         if reward.type == RewardType.CHARACTER:

--- a/event/opera_house_wob.py
+++ b/event/opera_house_wob.py
@@ -53,6 +53,8 @@ class OperaHouseWOB(Event):
         self.ultros_battle_mod()
         self.after_battle_mod()
 
+        self.grand_finale_mod()
+
         if self.reward.type == RewardType.CHARACTER:
             self.character_mod(self.reward.id)
         elif self.reward.type == RewardType.ESPER:
@@ -258,6 +260,16 @@ class OperaHouseWOB(Event):
             field.Call(field.ORIGINAL_CHECK_GAME_OVER),
         )
 
+    def grand_finale_mod(self):
+        formation = self.get_replacement_formation("Ultros 2")
+
+        # if bosses are random and multiple of one formation can appear,
+        # fighting this boss outside of the opera house will inform you this boss is in the opera house
+        dont_remove_music = self.args.boss_battles_random
+
+        formation.disable_battle_music = formation.disable_battle_music if dont_remove_music else 1
+        formation.disable_victory_dance = formation.disable_victory_dance if dont_remove_music else 1
+
     def after_battle_mod(self):
         # when maria changes to celes, a special celes sprite is used
         # change it to use normal celes sprite to allow customization and use a different pose
@@ -298,7 +310,7 @@ class OperaHouseWOB(Event):
         space.write(
             field.Call(show_celes),
         )
-       
+
         # do not animate the now hidden party leader
         space = Reserve(0xac28a, 0xac28d, "opera house do not turn party leader up", field.NOP())
         space = Reserve(0xac30d, 0xac312, "opera house do not move party leader up", field.NOP())


### PR DESCRIPTION
A quality of life that will play Grand Finale when you're fighting the boss in the Ultros 2 spot

This is disabled when bosses are `random` as duplicates of a boss would give information that the boss would be in the Opera House. 

Kind of a weird interaction