### PR TITLE
QoL: Showing MP in menus if character knows Lore but not Magic

### DIFF
--- a/data/lores.py
+++ b/data/lores.py
@@ -213,10 +213,50 @@ class Lores:
             battle_message = re.sub('<dotted line>', '“', lore.desc)
             dialogs.set_battle_message_text(self.DIALOG_OFFSET + lore_index, battle_message)
 
+    def show_mp_mod(self):
+        # Show Party member MP in menus if they have Lore, even if they don't know any Magic
+        # Thanks to Lenophis for most of this work: https://discord.com/channels/666661907628949504/931737764205047858/1054557544942673940
+        src = [
+            asm.JSR(0x30d2b, asm.ABS), # check to see if this character knows magic; this is displaced code
+            asm.BCS("magic_exit"),
+            # if we are at this point, we have a magic command but no magic.
+            # so now we are going to do a back-up check and see if a secondary command is present so MP can be shown
+            # if not, it will be grayed out as normal
+            asm.LDY(0x67, asm.DIR), # this gets set earlier in our route. Let's pull this character's index again for our back-up check
+            asm.LDX(0x0000, asm.IMM16),
+            "command_loop",
+            asm.LDA(0x0016, asm.ABS_Y),
+            asm.CMP(0x0C, asm.IMM8), # Lore
+            asm.BEQ("command_ok"),
+            asm.INY(),
+            asm.INX(),
+            asm.CPX(0x0004, asm.IMM16), # have we done 4 commands yet?
+            asm.BNE("command_loop"), # branch if not
+            # if we have exited the loop with no match, we need to flag MP to not show up
+            asm.CLC(),
+            asm.RTS(),
+            "command_ok",
+            # at this point, we have matched supplemental command, so let's flag MP as ok to show up
+            asm.SEC(),
+            "magic_exit",
+            asm.RTS(),
+        ]
+        space = Write(Bank.C3, src, "check for Lore")
+        mp_hook = space.start_address
+        space = Reserve(0x30cb7, 0x30cb9, "check for magic command")
+        space.write(
+            asm.JSR(mp_hook, asm.ABS),
+        )
+        space = Reserve(0x36134, 0x36136, "check for magic command 2")
+        space.write(
+            asm.JSR(mp_hook, asm.ABS),
+        )
+
     def mod(self, dialogs):
         self.write_learners_table()
         self.write_is_learner()
         self.after_battle_check_mod()
+        self.show_mp_mod()
 
         if self.args.start_lores_random:
             self.start_random_lores()


### PR DESCRIPTION
Tested with `-sc1 cyan -com 12981298989898989898989898 -sc2 gau -rec1 12 -sc3 celes`

![image](https://user-images.githubusercontent.com/96998881/209204549-1e891956-95fc-4dea-803b-db7b83dd0765.png)

Cyan doesn't know Magic, but his MP shows up in menu with this change because he knows Lore. Gau knows neither Lore nor Magic, so no MP. Celes knows Magic, so her MP shows up.

Thanks to Lenophis for the majority of this code.