### PR TITLE
QoL: Lenophis Esper Menu Spells Learned indicator

### DIFF
--- a/data/espers_asm.py
+++ b/data/espers_asm.py
@@ -1,4 +1,4 @@
-from memory.space import Bank, Reserve, Allocate, Write
+from memory.space import Bank, Reserve, Allocate, Write, Read
 import instruction.asm as asm
 
 def equipable_mod(espers):
@@ -7,8 +7,160 @@ def equipable_mod(espers):
     character_id_address = 0x1cf8
     gray_out_if_equipped = 0xc35576
     set_text_color = 0xc35595
+    equipped_esper_address = 0x161e
+    esper_spells_address = 0xd86e01
 
-    space = Allocate(Bank.C3, 145, "equipable espers", asm.NOP())
+    # Make completed espers yellow. Thanks to Lenophis for the asm
+
+    # Verify routine -- make sure an esper isn't already equipped
+    src = [
+        asm.BCC("esper_NOPE"), # coming in, if the carry is clear, it can't be equipped
+        asm.LDX(0x00, asm.DIR),
+        asm.TXY(),
+        "verify_loop",
+        asm.LDA(0xe0, asm.DIR), # load esper
+        asm.CMP(equipped_esper_address, asm.ABS_X), # does this character have this esper equipped already?
+        asm.BEQ("esper_NOPE"),
+        asm.A16(),
+        asm.TXA(),
+        asm.CLC(),
+        asm.ADC(0x0025, asm.IMM16),
+        asm.TAX(),
+        asm.TDC(),
+        asm.A8(),
+        asm.INY(),
+        asm.CPY(0x000c, asm.IMM16), # have we checked all available characters?
+        asm.BNE("verify_loop"),
+        # if after the entire loop nobody has it equipped, we can flag it as equippable! let's put it on!
+        asm.SEC(),
+        asm.RTS(),
+        "esper_NOPE",
+        # if somebody else already has this esper equipped, simply exit out and flag it as can't be equipped
+        asm.CLC(), # TODO: add flag to allow multi-equipped espers by removing this line
+        asm.RTS(),
+    ]
+    space = Write(Bank.C3, src, "verify esper isn't equipped")
+    verify_esper_equipped = space.start_address
+    print(f"verify_esper_equipped: {verify_esper_equipped:x}")
+
+    # We need to determine how many spells an esper teaches
+    # In: X = offset into esper_spell_address to first spell
+    src = [
+        asm.PHX(), # keep our current esper index
+        asm.STZ(0xb4, asm.DIR), # zero out our scratch for this indicator
+        asm.LDY(0x0005, asm.IMM16),
+        "esper_count_loop",
+        asm.LDA(esper_spells_address, asm.LNG_X), # load this esper's spell
+        asm.CMP(0xff, asm.IMM8), # no spell?
+        asm.BEQ("esper_spell_skip"),
+        asm.INC(0xb4, asm.DIR), # add one to this esper's spell count
+        "esper_spell_skip",
+        asm.INX(),
+        asm.INX(), # x+2 to get to next spell
+        asm.DEY(),
+        asm.BNE("esper_count_loop"),
+        asm.PLX(), # restore our esper index
+        asm.RTL(),
+    ]
+    space = Write(Bank.F0, src, "count esper spells")
+    esper_spell_count = space.start_address_snes
+
+    print(f"esper_spell_count: {esper_spell_count:x}")
+
+    # We need to re-make the "determine who is equipping which espers" routine, because of more checks we need to add
+    # We are adding in one additional check to see if a particular character has learned all of the spells that the esper teaches
+    src = [
+        asm.LDA(0xe0, asm.DIR), # load esper
+        asm.STA(0x4202, asm.ABS), # multiplier
+        asm.LDA(0x0b, asm.IMM8),  # 11 bytes per esper data at esper_spells_address
+        asm.STA(0x4203, asm.ABS), # multiplier
+        asm.NOP(), # wait
+        asm.STZ(0xb3, asm.DIR), # scratch RAM
+        asm.LDX(0x4216, asm.ABS), # load our product -- the offset into esper_spells_address
+        asm.JSL(esper_spell_count),
+        asm.LDY(0x0005, asm.IMM16), #each esper can teach up to 5 spells
+        "check_esper_spells_loop",
+        asm.LDA(esper_spells_address, asm.LNG_X), # load our spell that esper teaches
+        asm.CMP(0xff, asm.IMM8), # no spell?
+        asm.BEQ("check_count"), # branch and do our normal check if so. Note that we will not check any further in the loop since even in rando there isn't a spell after a no-entry
+        # if we are here, we have a spell to teach. Now we check to see if this character has learned it
+        asm.PHY(),
+        asm.LDY(0x67, asm.DIR), # load our character index
+        asm.LDA(0x0000, asm.ABS_Y), # load character ID
+        asm.STA(0x4202, asm.ABS), # multiplier
+        asm.LDA(0x36, asm.IMM8),
+        asm.STA(0x4203, asm.ABS), # multiplier
+        asm.TDC(),
+        asm.LDA(esper_spells_address, asm.LNG_X), # load our spell again
+        asm.A16(),
+        asm.CLC(),
+        asm.ADC(0x4216, asm.ABS), # add it to the product
+        asm.TAY(),
+        asm.A8(),
+        asm.TDC(),
+        asm.LDA(0x1a6e, asm.ABS_Y), # load spells known
+        asm.PLY(),
+        asm.CMP(0xff, asm.IMM8), # is this spell learned?
+        asm.BNE("check_count"), # branch and go do our normal check if not. We know this esper hasn't taught this character every spell it can
+        # at this point, this spell has been taught
+        asm.INC(0xb3, asm.DIR), # increment spell taught count
+        asm.INX(),
+        asm.INX(), # X + 2 to get to next spell (of 5)
+        asm.DEY(),
+        asm.BNE("check_esper_spells_loop"), # more spells to check
+        "check_count",
+        asm.LDA(0xb3, asm.DIR), # load our spell taught count
+        asm.CMP(0xb4, asm.DIR), # does it match the number of spells this esper teaches?
+        asm.BNE("set_white_or_gray"),
+        asm.LDA(0x30, asm.IMM8), # yellow text to indicate we're learned all spells
+        asm.STA(0x29, asm.DIR), # update text color
+        asm.STZ(0xb3, asm.DIR), # zero out scratch again, just in case
+        asm.STZ(0xb4, asm.DIR), # zero out scratch again, just in case
+        asm.LDA(0xe0, asm.DIR),
+        asm.SEC(), # set carry to indicate to verify_esper_equipped that it may be equippable
+        asm.RTS(),
+
+        "set_white_or_gray",
+        asm.LDX(0x00, asm.DIR),
+        asm.LDY(0x0010, asm.IMM16),
+        "loop",
+        asm.LDA(equipped_esper_address, asm.ABS_X), # esper equipped by this character
+        asm.CMP(0xe0, asm.DIR), # does it match?
+        asm.BEQ("set_gray"), # branch if so, exit out
+        asm.A16(),
+        asm.TXA(),
+        asm.CLC(),
+        asm.ADC(0x0025, asm.IMM16), 
+        asm.TAX(),
+        asm.A8(),
+        asm.DEY(),
+        asm.BNE("loop"),
+        asm.LDA(0x20, asm.IMM8), # if we got here, it's not equipped. Set white text
+        asm.BRA("skip_one"),
+        "set_gray",
+        asm.LDA(0x2c, asm.IMM8), # gray text, blue background
+        "skip_one",
+        asm.STA(0x29, asm.DIR), # update text color
+        asm.STZ(0xb3, asm.DIR), # zero out our scratch again, just in case
+        asm.STZ(0xb4, asm.DIR), # zero out our scratch again, just in case
+        asm.LDA(0xe0, asm.DIR),
+        asm.SEC(), # set carry to indicate to verify_esper_equipped that it may be equippable
+        asm.RTS(),
+    ]
+    space = Write(Bank.C3, src, "check if character has learned all spells")
+    learned_all_check = space.start_address
+
+    print(f"learned_all_check: {learned_all_check:x}")
+
+    space = Reserve(0x358e6, 0x358eb, "equip esper if name not grayed out", asm.NOP())
+    space.add_label("EQUIP_ESPER", 0x35902)
+    space.write(
+        asm.JSR(verify_esper_equipped, asm.ABS),
+        asm.BCS("EQUIP_ESPER"),
+    )
+    # end lenophis edit
+
+    space = Allocate(Bank.C3, 146, "equipable espers", asm.NOP())
 
     equip_table = space.next_address
     for esper in espers.espers:
@@ -42,11 +194,12 @@ def equipable_mod(espers):
         asm.BEQ("NOT_EQUIPABLE"),       # branch if result is zero
         asm.PLP(),
         asm.PLX(),
-        asm.JMP(gray_out_if_equipped, asm.ABS),
+        asm.JMP(learned_all_check, asm.ABS),
 
         "NOT_EQUIPABLE",
         asm.PLP(),
         asm.PLX(),
+        asm.CLC(), # clear carry to indicate to verify_esper_equipped that it can't be equipped
         asm.LDA(0x28, asm.IMM8),        # load text color (gray)
         asm.JMP(set_text_color, asm.ABS),
     )
@@ -114,7 +267,7 @@ def equipable_mod(espers):
         asm.JSR(check_equipable, asm.ABS),
     )
 
-    space = Reserve(0x358e1, 0x358e5, "load esper palette", asm.NOP())
+    space = Reserve(0x358e1, 0x358e3, "load esper palette", asm.NOP())
     space.write(
         asm.JSR(check_equipable, asm.ABS),
     )
@@ -124,9 +277,3 @@ def equipable_mod(espers):
         asm.JSR(check_equipable, asm.ABS),
     )
 
-    space = Reserve(0x358e8, 0x358eb, "equip esper if name not grayed out", asm.NOP())
-    space.add_label("EQUIP_ESPER", 0x35902)
-    space.write(
-        asm.CMP(0x20, asm.IMM8),
-        asm.BEQ("EQUIP_ESPER"),
-    )

--- a/instruction/f0.py
+++ b/instruction/f0.py
@@ -55,6 +55,25 @@ def _set_gray_text_color_mod():
     return space.start_address
 set_gray_text_color = _set_gray_text_color_mod()
 
+def _set_yellow_text_color_mod():
+    # make yellow text available on bg1 by updating palette. Credit to Lenophis
+    src = [
+        0x00, 0x00,
+        0xce, 0x39,
+        0xbf, 0x03,
+    ]
+    space = Reserve(0x18e882, 0x18e887, "bg1 text color palette")
+    space.write(src)
+
+    src = [
+        asm.LDA(0x30, asm.IMM8),
+        asm.STA(0x29, asm.DIR),
+        asm.RTS(),
+    ]
+    space = Write(Bank.F0, src, "f0 set yellow text color in menu")
+    return space.start_address
+set_yellow_text_color = _set_yellow_text_color_mod()
+
 def _boss_formations_mod():
     from data.bosses import normal_formation_name
 


### PR DESCRIPTION
Credit for most of this work goes to Lenophis. 

Update the espers menu to indicate the espers for which the character has already learned all spells.

https://discord.com/channels/666661907628949504/666811498668228609/1063041900224983060

Work to go: 
- Add flag to disable this logic if desired
- Clean up code in espers_asm
- Make it so that an esper is shown in gray if it's already equipped by another character, regardless of whether all spells have been learned.
- Determine if more logic can move to f0