### PR TITLE
feature: filter low value items

### DIFF
--- a/args/chests.py
+++ b/args/chests.py
@@ -18,6 +18,12 @@ def parse(parser):
     chests.add_argument("-cms", "--chest-monsters-shuffle", action = "store_true",
                         help = "Monsters-in-a-box shuffled but locations unchanged")
 
+    chests.add_argument("-ntc", "--no-trash-chests",  action = "store_true",
+                       help="Replace Low Tier Items with gold in chests")
+
+
+
+
 def process(args):
     if args.chest_contents_shuffle_random is not None:
         args.chest_contents_shuffle_random_percent = args.chest_contents_shuffle_random
@@ -37,6 +43,8 @@ def flags(args):
 
     if args.chest_monsters_shuffle:
         flags += " -cms"
+    if args.no_trash_chests:
+        flags += " -ntc"
 
     return flags
 

--- a/args/chests.py
+++ b/args/chests.py
@@ -66,6 +66,10 @@ def options(args):
         result.append(("Random Percent", f"{args.chest_contents_shuffle_random_percent}%"))
     result.append(("Monsters-In-A-Box Shuffled", args.chest_monsters_shuffle))
 
+    if args.no_trash_chests:
+        result.append(("No Trash Chests", args.no_trash_chests))
+
+
     return result
 
 def menu(args):

--- a/args/items.py
+++ b/args/items.py
@@ -49,6 +49,9 @@ def parse(parser):
     items.add_argument("-saw", "--stronger-atma-weapon", action = "store_true",
                        help = "Atma Weapon moved to higher tier and divisor reduced from 64 to 32")
 
+    items.add_argument("-nti", "--no-trash-items",  action = "store_true",
+                       help="Replace Low Tier Items with gold in chests and skip adding to shop lists")
+
 def process(args):
     args._process_min_max("item_equipable_random")
     if args.item_equipable_balanced_random is not None:
@@ -107,6 +110,8 @@ def flags(args):
 
     if args.stronger_atma_weapon:
         flags += " -saw"
+    if args.no_trash_items:
+        flags += " -nti"
 
     return flags
 

--- a/args/items.py
+++ b/args/items.py
@@ -49,8 +49,11 @@ def parse(parser):
     items.add_argument("-saw", "--stronger-atma-weapon", action = "store_true",
                        help = "Atma Weapon moved to higher tier and divisor reduced from 64 to 32")
 
-    items.add_argument("-nti", "--no-trash-items",  action = "store_true",
-                       help="Replace Low Tier Items with gold in chests and skip adding to shop lists")
+    items.add_argument("-ntc", "--no-trash-chests",  action = "store_true",
+                       help="Replace Low Tier Items with gold in chests")
+
+    items.add_argument("-nts", "--no-trash-shops",  action = "store_true",
+                       help="Omit Low tier items in shops")
 
 def process(args):
     args._process_min_max("item_equipable_random")
@@ -110,9 +113,10 @@ def flags(args):
 
     if args.stronger_atma_weapon:
         flags += " -saw"
-    if args.no_trash_items:
-        flags += " -nti"
-
+    if args.no_trash_chests:
+        flags += " -ntc"
+    if args.no_trash_shops:
+        flags += " -nts"
     return flags
 
 def options(args):

--- a/args/items.py
+++ b/args/items.py
@@ -49,11 +49,7 @@ def parse(parser):
     items.add_argument("-saw", "--stronger-atma-weapon", action = "store_true",
                        help = "Atma Weapon moved to higher tier and divisor reduced from 64 to 32")
 
-    items.add_argument("-ntc", "--no-trash-chests",  action = "store_true",
-                       help="Replace Low Tier Items with gold in chests")
 
-    items.add_argument("-nts", "--no-trash-shops",  action = "store_true",
-                       help="Omit Low tier items in shops")
 
 def process(args):
     args._process_min_max("item_equipable_random")
@@ -113,10 +109,8 @@ def flags(args):
 
     if args.stronger_atma_weapon:
         flags += " -saw"
-    if args.no_trash_chests:
-        flags += " -ntc"
-    if args.no_trash_shops:
-        flags += " -nts"
+
+
     return flags
 
 def options(args):

--- a/args/shops.py
+++ b/args/shops.py
@@ -165,6 +165,7 @@ def options(args):
         ("Expensive Balls", args.shops_expensive_super_balls),
         ("No Exp. Eggs", args.shops_no_exp_eggs),
         ("No Illuminas", args.shops_no_illuminas),
+        ("No Trash Shops", args.no_trash_shops)
     ])
     return result
 

--- a/args/shops.py
+++ b/args/shops.py
@@ -53,6 +53,9 @@ def parse(parser):
     shops.add_argument("-snil", "--shops-no-illuminas", action = "store_true",
                        help = "Illuminas not sold in shops")
 
+    shops.add_argument("-nts", "--no-trash-shops",  action = "store_true",
+                       help="Omit Low tier items in shops")
+
 def process(args):
     if args.shop_inventory_shuffle_random is not None:
         args.shop_inventory_shuffle_random_percent = args.shop_inventory_shuffle_random
@@ -105,6 +108,9 @@ def flags(args):
         flags += " -snee"
     if args.shops_no_illuminas:
         flags += " -snil"
+
+    if args.no_trash_shops:
+        flags += " -nts"
 
     return flags
 

--- a/constants/items.py
+++ b/constants/items.py
@@ -295,3 +295,24 @@ good_items = [
     "Marvel Shoes",
     "Exp. Egg",
 ]
+
+## TRASH LIST https://docs.google.com/spreadsheets/d/1Cit5Xl_TCBPFI4q1NEVQhSYGH1wKY9st_1yee3lzCP8/edit#gid=0
+
+TRASH_WEAPONS = [
+    "Dirk", "MithrilKnife", "Guardian", "MithrilBlade", "RegalCutlass", "Crystal", "Ogre Nix", "Mithril Pike",
+    "Stout Spear", "Gold Lance", "Partisan", "Imperial", "Kodachi", "Hardened", "Ashura", "Kotetsu", "Forged",
+    "Aura", "Strato", "Poison Rod", "Punisher", "Gravity Rod", "MetalKnuckle", "Mithril Claw", "Kaiser",
+    "Flail", "Morning Star", "Full Moon", "Boomerang", "Rising Sun", "Cards", "Darts", "Chocobo Brsh", "DaVinci Brsh"
+    ]
+
+TRASH_ARMOR = ["Buckler", "Mithril Shld", "Heavy Shld", "Gold Shld", "Leather Hat", "Plumed Hat", "Bandana",
+               "Iron Helmet", "Mithril Helm", "Gold Helmet", "LeatherArmor", "Kung Fu Suit", "Mithril Vest",
+               "Diamond Vest", "Cotton Robe", "Silk Robe", "Iron Armor", "DiamondArmor", "Crystal Mail",
+               "Mithril Mail"
+]
+TRASH_RElICS = ["Charm Bangle", "Coin Toss", "FakeMustache"]
+
+
+TRASH_ITEMS = TRASH_WEAPONS + TRASH_ARMOR + TRASH_RElICS
+
+TRASH_IDS = [name_id.get(value) for value in TRASH_ITEMS]

--- a/constants/items.py
+++ b/constants/items.py
@@ -299,10 +299,10 @@ good_items = [
 ## TRASH LIST https://docs.google.com/spreadsheets/d/1Cit5Xl_TCBPFI4q1NEVQhSYGH1wKY9st_1yee3lzCP8/edit#gid=0
 
 TRASH_WEAPONS = [
-    "Dirk", "MithrilKnife", "Guardian", "MithrilBlade", "RegalCutlass", "Crystal", "Ogre Nix", "Mithril Pike",
-    "Stout Spear", "Gold Lance", "Partisan", "Imperial", "Kodachi", "Hardened", "Ashura", "Kotetsu", "Forged",
-    "Aura", "Strato", "Poison Rod", "Punisher", "Gravity Rod", "MetalKnuckle", "Mithril Claw", "Kaiser",
-    "Flail", "Morning Star", "Full Moon", "Boomerang", "Rising Sun", "Cards", "Darts", "Chocobo Brsh", "DaVinci Brsh"
+    "Dirk", "MithrilKnife", "Guardian", "MithrilBlade", "RegalCutlass", "Crystal", "Mithril Pike",
+    "Stout Spear",  "Imperial", "Kodachi", "Hardened", "Ashura", "Kotetsu", "Forged",
+    "Aura", "Strato", "Punisher", "MetalKnuckle", "Mithril Claw", "Kaiser",
+    "Flail", "Morning Star", "Full Moon", "Boomerang", "Rising Sun", "Cards", "Darts", "Chocobo Brsh",
     ]
 
 TRASH_ARMOR = ["Buckler", "Mithril Shld", "Heavy Shld", "Gold Shld", "Leather Hat", "Plumed Hat", "Bandana",

--- a/constants/items.py
+++ b/constants/items.py
@@ -307,7 +307,8 @@ TRASH_WEAPONS = [
 
 TRASH_ARMOR = ["Buckler", "Mithril Shld", "Heavy Shld", "Gold Shld", "Leather Hat", "Plumed Hat", "Bandana",
                "Iron Helmet", "Mithril Helm", "Gold Helmet", "LeatherArmor", "Kung Fu Suit", "Mithril Vest",
-               "Diamond Vest", "Cotton Robe", "Silk Robe", "Iron Armor", "DiamondArmor", "Crystal Mail",
+               "Diamond Vest", "Cotton Robe", "Silk Robe", "Iron Armor",
+               "DiamondArmor", "Crystal Mail", "Gold Armor",
                "Mithril Mail"
 ]
 TRASH_RElICS = ["Charm Bangle", "Coin Toss", "FakeMustache"]

--- a/data/chests.py
+++ b/data/chests.py
@@ -107,15 +107,24 @@ class Chests():
                 chest.contents = self.items.get_random()
 
         if self.args.no_trash_chests:
+            if self.args.shop_sell_fraction4:
+                sell_factor = 1/4
+            elif self.args.shop_sell_fraction8:
+                sell_factor = 1 / 8
+            elif self.args.shop_sell_fraction0:
+                sell_factor = 0
+            else:
+                sell_factor = 1/2
             for chest in possible_chests:
                 if not chest.type == Chest.ITEM:
                     continue
                 item = Item(chest.contents, self.rom)
                 if item.is_trash:
+                    item_chest_value = int(min((item.price * sell_factor)//100, Chest.MAX_GOLD_VALUE))
                     if not item.sell_gold_value:
                         chest.type = Chest.EMPTY
                     chest.type = Chest.GOLD
-                    chest.contents = item.sell_gold_value
+                    chest.contents = item_chest_value
 
 
     def random_tiered(self):

--- a/data/chests.py
+++ b/data/chests.py
@@ -112,6 +112,8 @@ class Chests():
                     continue
                 item = Item(chest.contents, self.rom)
                 if item.is_trash:
+                    if not item.sell_gold_value:
+                        chest.type = Chest.EMPTY
                     chest.type = Chest.GOLD
                     chest.contents = item.sell_gold_value
 

--- a/data/chests.py
+++ b/data/chests.py
@@ -106,7 +106,7 @@ class Chests():
             elif chest.type == Chest.ITEM:
                 chest.contents = self.items.get_random()
 
-        if self.args.no_trash_items:
+        if self.args.no_trash_chests:
             for chest in possible_chests:
                 if not chest.type == Chest.ITEM:
                     continue

--- a/data/chests.py
+++ b/data/chests.py
@@ -1,5 +1,6 @@
 from data.chest import Chest
 import data.chests_asm as chests_asm
+from data.item import Item
 from data.structures import DataArrays
 import random
 
@@ -104,6 +105,16 @@ class Chests():
                 chest.randomize_gold()
             elif chest.type == Chest.ITEM:
                 chest.contents = self.items.get_random()
+
+        if self.args.no_trash_items:
+            for chest in possible_chests:
+                if not chest.type == Chest.ITEM:
+                    continue
+                item = Item(chest.contents, self.rom)
+                if item.is_trash:
+                    chest.type = Chest.GOLD
+                    chest.contents = item.sell_gold_value
+
 
     def random_tiered(self):
         def get_item(tiers, tier_s_distribution):

--- a/data/item.py
+++ b/data/item.py
@@ -1,4 +1,5 @@
 import data.text as text
+from constants.items import TRASH_IDS
 from data.text.text2 import text_value, value_text
 
 class Item():
@@ -19,6 +20,10 @@ class Item():
         self.data_addr = self.DATA_START_ADDR + self.id * self.DATA_SIZE
 
         self.read()
+
+    @property
+    def is_trash(self):
+        return self.id in TRASH_IDS
 
     def is_equipable(self):
         return self.equipable_characters
@@ -41,6 +46,11 @@ class Item():
     def remove_learnable_spell(self):
         self.learnable_spell = 0
         self.learnable_spell_rate = 0
+
+    @property
+    def sell_gold_value(self):
+        ## half price for sell and //100
+        return self.price//200
 
     def scale_price(self, factor):
         self.price = int(self.price * factor)

--- a/data/shops.py
+++ b/data/shops.py
@@ -1,3 +1,5 @@
+from constants.items import TRASH_IDS
+from data.item import Item
 from data.shop import Shop
 from data.structures import DataArray
 
@@ -226,6 +228,8 @@ class Shops():
             exclude.append(self.items.get_id("Exp. Egg"))
         if self.args.shops_no_illuminas:
             exclude.append(self.items.get_id("Illumina"))
+        if self.args.no_trash_items:
+            exclude.extend(TRASH_IDS)
 
         for shop in self.shops:
             for item in exclude:

--- a/data/shops.py
+++ b/data/shops.py
@@ -228,7 +228,7 @@ class Shops():
             exclude.append(self.items.get_id("Exp. Egg"))
         if self.args.shops_no_illuminas:
             exclude.append(self.items.get_id("Illumina"))
-        if self.args.no_trash_items:
+        if self.args.no_trash_shops:
             exclude.extend(TRASH_IDS)
 
         for shop in self.shops:


### PR DESCRIPTION
feature: Add filtering of low value items from shops and chests. flag…: -nti --no-trash-items

Replacing low value items in chests with their sell GP value
added sell_value and is_trash props to Item

created list of trash items using: https://docs.google.com/spreadsheets/d/1Cit5Xl_TCBPFI4q1NEVQhSYGH1wKY9st_1yee3lzCP8/edit#gid=174771622
Filtered out armors that were bad and had no bonus 
Removed ["Charm Bangle", "Coin Toss", "FakeMustache"] just to have a couple relics out of the pool

Trash items are added to excluded items for shops
and low value chests are converted during shuffle_random
