### PR TITLE
Bugfix: Vargas B-Dash

### DIFF
--- a/event/mt_kolts.py
+++ b/event/mt_kolts.py
@@ -21,6 +21,7 @@ class MtKolts(Event):
         self.shadow_vargas_mod()
         self.vargas_battle_mod()
         self.entrance_exit_mod()
+        self.vargas_trigger_mod()
 
         if self.reward.type == RewardType.CHARACTER:
             self.character_mod(self.reward.id)
@@ -138,6 +139,29 @@ class MtKolts(Event):
         new_event.y = 59
         new_event.event_address = exit_move_airship - EVENT_CODE_START
         self.maps.add_event(0x64, new_event)
+
+    def vargas_trigger_mod(self):
+        # Vargas appears on the map 0x62 via 2 tile triggers. With B-Dash, players can outpace him leading to soft-locks.
+        # Change the 2 event tile triggers to a different location.
+        old_event = self.maps.get_event(0x62, 10, 32) # get existing event
+
+        self.maps.delete_event(0x62, 10, 32) # vargas event tile (left)
+        self.maps.delete_event(0x62, 11, 32) # vargas event tile (right)
+
+        from data.map_event import MapEvent
+        # add event tile to earlier on the path
+        new_event = MapEvent()
+        new_event.x = 21
+        new_event.y = 19
+        new_event.event_address = old_event.event_address
+        self.maps.add_event(0x62, new_event)
+
+        # add event tile to bottom right of stairs
+        new_event = MapEvent()
+        new_event.x = 21
+        new_event.y = 20
+        new_event.event_address = old_event.event_address
+        self.maps.add_event(0x62, new_event)
 
     def character_mod(self, character):
         boss_pack_id = self.get_boss("Vargas")

--- a/settings/permadeath.py
+++ b/settings/permadeath.py
@@ -13,6 +13,7 @@ class Permadeath:
         if args.permadeath:
             self.remove_status_mod(remove_status_space)
             self.heal_hp_mod(heal_hp_space)
+            self.coliseum_mod()
 
     def remove_status_mod(self, space):
         # change remove status effects field command to never remove death
@@ -47,3 +48,8 @@ class Permadeath:
         space.write(
             asm.JMP(death_or_max_hp, asm.ABS),
         )
+
+    def coliseum_mod(self):
+        # don't revive permadeath characters by retaining the wound bit
+        space = Reserve(0x227f3, 0x227f3, "coliseum permadeath")
+        space.write(0xad) # default: 0x2d, which clears the wound bit


### PR DESCRIPTION
Moving the event tiles that cause vargas to appear earlier on the map, to avoid bugs with b-dash in which the player can catch up.

Fix tested: https://www.youtube.com/watch?v=qpxthbrDmy4&ab_channel=SilverThorn

Vanilla event tile (blue):
![image](https://user-images.githubusercontent.com/96998881/226207749-76b99a39-b0e4-41bc-a1dc-ec01b3039716.png)

New event tile (with NPC passability shown):
![image](https://user-images.githubusercontent.com/96998881/226207774-59fd7da3-169f-460d-9acc-05d9476a4ce1.png)
