### PR TITLE
Fix cid timer bug

### DIFF
--- a/data/map_event.py
+++ b/data/map_event.py
@@ -28,3 +28,43 @@ class MapEvent():
 
     def print(self):
         print("{}, {}: {}".format(self.x, self.y, hex(self.event_address)))
+
+
+class LongMapEvent():
+    # By analogy to LongMapExit()
+    DATA_SIZE = 0x06
+
+    def __init__(self):
+        self.x = 0
+        self.y = 0
+        self.size = 0
+        self.direction = 0
+        self.event_address = 0
+
+    def from_data(self, data):
+        assert(len(data) == self.DATA_SIZE)
+
+        self.x = data[0]
+        self.y = data[1]
+
+        self.event_address = data[2] | (data[3] << 8) | (data[4] << 16)
+
+        self.size = data[5] & 0x7f  # tile length
+        self.direction = data[5] & 0x80  # 0 = horizontal, 128 = vertical
+
+    def to_data(self):
+        data = [0x00] * self.DATA_SIZE
+
+        data[0] = self.x
+        data[1] = self.y
+
+        data[2] = self.event_address & 0xff
+        data[3] = (self.event_address & 0xff00) >> 8
+        data[4] = (self.event_address & 0xff0000) >> 16
+
+        data[5] = self.size | self.direction
+
+        return data
+
+    def print(self):
+        print("{}, {}, {}, {}: {}".format(self.x, self.y, self.size, self.direction, hex(self.event_address)))

--- a/data/map_events.py
+++ b/data/map_events.py
@@ -1,6 +1,7 @@
-from data.map_event import MapEvent
+from data.map_event import MapEvent, LongMapEvent
+from event.event import *
 
-class MapEvents():
+class MapEvents:
     EVENT_COUNT = 1164
     DATA_START_ADDR = 0x040342
 
@@ -53,3 +54,213 @@ class MapEvents():
     def print(self):
         for event in self.events:
             event.print()
+
+
+class LongMapEvents:
+    EVENT_COUNT = 0
+    POINTER_START_ADDR_LONG = 0x320000  # Bank $F2.  Set dynamically?
+    DATA_START_ADDR_LONG = 0x320342
+    verbose = False
+
+    def __init__(self, rom):
+        self.rom = rom
+        self.read()
+
+        # Modify the ROM to add long events
+        self.addLongEvents()
+
+    def read(self):
+        # by default, no LongMapEvents in the rom
+        self.events = []
+
+        for event_index in range(self.EVENT_COUNT):
+            event_data_start = self.DATA_START_ADDR_LONG + event_index * LongMapEvent.DATA_SIZE
+            event_data = self.rom.get_bytes(event_data_start, LongMapEvent.DATA_SIZE)
+
+            new_event = LongMapEvent()
+            new_event.from_data(event_data)
+            self.events.append(new_event)
+
+    def write(self):
+        for event_index, event in enumerate(self.events):
+            event_data = event.to_data()
+            event_data_start = self.DATA_START_ADDR_LONG + event_index * LongMapEvent.DATA_SIZE
+            self.rom.set_bytes(event_data_start, event_data)
+
+    def mod(self):
+        pass
+
+    def get_event(self, search_start, search_end, x, y):
+        for event in self.events[search_start:search_end + 1]:
+            if event.x == x and event.y == y:
+                return event
+        raise IndexError(f"get_event: could not find event at {x} {y}")
+
+    def add_event(self, index, new_event):
+        self.events.insert(index, new_event)
+        self.EVENT_COUNT += 1
+
+    def delete_event(self, search_start, search_end, x, y):
+        for event in self.events[search_start:search_end + 1]:
+            if event.x == x and event.y == y:
+                self.events.remove(event)
+                self.EVENT_COUNT -= 1
+                return
+        raise IndexError("delete_event: could not find event at {x} {y}")
+
+    def print_range(self, start, count):
+        for offset in range(count):
+            self.events[start + offset].print()
+
+    def print(self):
+        for event in self.events:
+            event.print()
+
+    def addLongEvents(self):
+        # Modify the ROM to check for long events in the field program & include long event pointers
+        # (Following Lenophis' code implementing long events, the event equivalent of long exits)
+        ROM_OFFSET = 0xC00000
+
+        # long event triggers
+        src = [
+            # CHECK IF THERE IS A LONG EVENT ON THIS MAP
+            asm.LDA(0x82, asm.DIR), # C08C7B:    LDA $82   [A5 82]
+            asm.ASL(),           # C08C7D:    ASL A     [0A]
+            asm.TAX(),           # C08C7E:    TAX       [AA]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 2, asm.LNG_X),
+                                 # C08C7F:    LDA $F40002, X; load second pointer   [BF XX XX XX]
+            asm.STA(0x1e, asm.DIR), # C08C83:    STA $1E   [85 1E]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET, asm.LNG_X),
+                                 # C08C85:    LDA $F40000, X; load first pointer    [BF XX XX XX]
+            asm.TAX(),           # C08C89:    TAX;  put first pointer address in X  [AA]
+            asm.CMP(0x1e, asm.DIR), # C08C8A:    CMP $1E  [C5 1E]
+            asm.BEQ("DO_NORMAL_TRIGGERS"), # C08C8C:    BEQ C08CE8; branch if they do match, we don't have a trigger in this map
+                                 # Jump forward 0x5a lines?  Check this.    [F0 5A]
+
+            # FOUND A LONG EVENT TRIGGER ON THE MAP.  CHECK VERTICAL OR HORIZONTAL.
+            "ITERATE_LONG_EVENT", # ASM label for checking each long event
+            asm.TDC(),           # C08C8E:    TDC           [7B]
+            asm.SEP(0x20),       # C08C8F:    SEP  # $20    [E2 20]
+            asm.STZ(0x26, asm.DIR), # C08C91:    STZ $26       [64 26]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 5, asm.LNG_X),
+                                 # C08C93:    LDA $F40002, X; load trigger's length [BF XX XX XX]
+                                 # NOTE: the trigger horiz/vert value is the 5th bit
+                                 #       (to maintain similarity to normal events)
+            asm.BMI("IS_VERTICAL_EVENT"), # C08C97:    BMI C08CBB; branch if vertical    [30 22]
+
+
+            # HORIZONTAL TRIGGER CASE
+            asm.STA(0x1a, asm.DIR), # C08C99:    STA $1A       [85 1A]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 1, asm.LNG_X),
+                                 # C08C9B:    LDA $F40001, X; load trigger's Y coordinate   [BF XX XX XX]
+            asm.CMP(0xb0, asm.DIR), # C08C9F:    CMP $B0; compare to current Y position    [C5 B0]
+            asm.BNE("SKIP_THIS_EVENT"),       # C08CA1:    BNE C08CDD; if they don't match, check the next trigger  [D0 3A]
+            asm.LDA(0xaf, asm.DIR), # C08CA3:    LDA $AF; load current X position  [A5 AF]
+            asm.SEC(),           # C08CA5:    SEC (set carry flag)     [38]
+            asm.SBC(self.POINTER_START_ADDR_LONG + ROM_OFFSET, asm.LNG_X),
+                                 # C08CA6:    SBC $F40000, X; subtract trigger's X coordinate    [FF XX XX XX]
+            asm.BCC("SKIP_THIS_EVENT"),       # C08CAA:    BCC C08CDD (branch if carry clear) [90 31]
+            asm.STA(0x26, asm.DIR), # C08CAC:    STA $26       [85 26]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET, asm.LNG_X),
+                                 # C08CAE:    LDA $F40000, X; load trigger's X coordinate        [BF XX XX XX]
+            asm.CLC(),           # C08CB2:    CLC (clear carry flag)    [18]
+            asm.ADC(0x1a, asm.DIR), # C08CB3:    ADC $1A; add in length    [65 1A]
+            asm.CMP(0xaf, asm.DIR), # C08CB5:    CMP $AF; compare to current X position    [C5 AF]
+            asm.BCS("TRIGGER_LONG_EVENT"),    # C08CB7:    BCS C08CEC; trigger the event (branch if carry set) [B0 33]
+            asm.BRA("SKIP_THIS_EVENT"),       # C08CB9:    BRA C08CDD (branch always) [80 22]
+
+            # VERTICAL LONG EVENT TRIGGER CHECK
+            "IS_VERTICAL_EVENT",  # ASM label for vertical event
+            asm.AND(0x7f, asm.IMM8), # C08CBB:    AND  # $7F  ; remove vertical flag       [29 7F]
+            asm.STA(0x1a, asm.DIR), # C08CBD:    STA $1A       [85 1A]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET, asm.LNG_X),
+                                 # C08CBF:    LDA $F40000, X; load trigger's X coordinate       [BF XX XX XX]
+            asm.CMP(0xaf, asm.DIR), # C08CC3:    CMP $AF; compare to current X position    [C5 AF]
+            asm.BNE("SKIP_THIS_EVENT"),       # C08CC5:    BNE C08CDD  (branch if not equal)         [D0 16]
+            asm.LDA(0xb0, asm.DIR), # C08CC7:    LDA $B0       [A5 B0]
+            asm.SEC(),           # C08CC9:    SEC           [38]
+            asm.SBC(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 1, asm.LNG_X),
+                                 # C08CCA:    SBC $F40001, X; subtract trigger's Y coordinate   [FF XX XX XX]
+            asm.BCC("SKIP_THIS_EVENT"),       # C08CCE:    BCC C08CDD (branch if carry clear)        [90 0D]
+            asm.STA(0x26, asm.DIR), # C08CD0:    STA $26       [85 26]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 1, asm.LNG_X),
+                                 # C08CD2:    LDA $F40001, X; load trigger's Y coordinate       [BF XX XX XX]
+            asm.CLC(),           # C08CD6:    CLC               [18]
+            asm.ADC(0x1a, asm.DIR), # C08CD7:    ADC $1A; add in length    [65 1A]
+            asm.CMP(0xb0, asm.DIR), # C08CD9:    CMP $B0; compare to current Y position?   [C5 B0]
+            asm.BCS("TRIGGER_LONG_EVENT"),       # C08CDB:    BCS C08CEC; trigger the event (branch if carry set) [B0 0F]
+
+            # ITERATE TO NEXT TRIGGER
+            "SKIP_THIS_EVENT",  # ASM label for moving on to the next trigger
+            asm.REP(0x21),       # C08CDD:    REP  # $21 (reset status bit)  [C2 21]
+            asm.TXA(),           # C08CDF:    TXA  (transfer X to A)         [8A]
+            asm.ADC(0x0006, asm.IMM16), # C08CE0:    ADC  # $0006 (add with carry) [69 06 00]
+            asm.TAX(),           # C08CE3:    TAX  (transfer A to X)         [AA]
+            asm.CPX(0x1e, asm.DIR), # C08CE4:    CPX $1E (compare X)            [E4 1E]
+            asm.BNE("ITERATE_LONG_EVENT"),       # C08CE6:    BNE C08C8E   [D0 A6]
+
+            # MOVE ON TO NORMAL TRIGGERS
+            "DO_NORMAL_TRIGGERS", # ASM label for moving on to normal triggers
+            asm.LDA(0x82, asm.DIR), # C08CE8:    LDA $82; otherwise let's do normal event triggers [A5 82]
+            asm.ASL(),           # C08CEA:    ASL A     [0A]
+            asm.RTS(),           # C08CEB:    RTS       [60]
+
+            # TRIGGER THE EVENT: see e.g. C0/BCD3 for normal events.
+            "TRIGGER_LONG_EVENT", # ASM label for triggering long event
+            asm.REP(0x20),       # C08CEC:    REP  # $20  ; (reset status bits)        [C2 20]
+                                 # 'we must copy the whole address, not just the first byte :P'
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 2, asm.LNG_X),
+                                 # C08CEE:    LDA $F40003, X; lower 2 bytes of trigger address  [BF XX XX XX]
+                                 # Data structure:  [x, y, trig_lo, trig_mid, trig_hi, d&size]
+                                 # (Lenophis used: [x, y, d&size, trigger])
+            asm.STA(0xe5, asm.DIR),     # C08CF2:    STA $E5   (store A to memory)     [85 E5]
+            asm.STA(0x05f4, asm.ABS),   # C08CF4:    STA $05F4                    [8D F4 05]
+            asm.SEP(0x20),           # C08CF7:    SEP  # $20 (set status bit 0x20)  [E2 20]
+            asm.TDC(),               # C08CF9:    TDC  (Transfer DP to 16 bit A)    [7B]
+            asm.STA(0x0871, asm.ABS_Y), # C08CFA:    STA $0871, Y  (store A to mem, indexed by Y)  [99 71 08]
+            asm.STA(0x0873, asm.ABS_Y), # C08CFD:    STA $0873, Y                  [99 73 08]
+            asm.SEP(0x20),           # C08D00:    SEP  # $20                    [E2 20]
+            asm.STA(0x087E, asm.ABS_Y), # C08D02:    STA $087E, Y                  [99 7E 08]
+            asm.LDA(0x01, asm.IMM8),    # C08D05:    LDA  # $01                    [A9 01]
+            asm.STA(0x078e, asm.ABS),   # C08D07:    STA $078E                     [8D 8E 07]
+            asm.STA(0x05c7, asm.ABS),   # C08D0A:    STA $05C7                     [8D C7 05]
+            asm.LDA(self.POINTER_START_ADDR_LONG + ROM_OFFSET + 4, asm.LNG_X),
+                                # C08D0D:    LDA $F40005, X; load high byte of trigger address  [BF XX XX XX]
+                                # Data structure:  [x, y, trig_lo, trig_mid, trig_hi, d&size]
+            asm.CLC(),          # C08D11:    CLC   [18]
+            # # C08D12:; JMP C0ED8E   I think we can skip this?
+            asm.ADC(0xca, asm.IMM8),    # C0ED8E:    ADC  # $CA                    [69 CA]
+            asm.STA(0xe7, asm.DIR),     # C0ED90:    STA $E7                       [85 E7]
+            asm.STA(0x05f6, asm.ABS),   # C0ED92:    STA $05F6                     [8D F6 05]
+            asm.LDX(0x00, asm.DIR),     # C0ED95:    LDX $00                       [A6 00]
+                                # Note: standard event code uses LDX(0x0000, 'IMM16') [A2 00 00]
+            asm.STX(0x0594, asm.ABS),   # C0ED97:    STX $0594                     [8E 94 05]
+            asm.LDA(0xca, asm.IMM8),    # C0ED9A:    LDA  # $CA                    [A9 CA]
+            asm.STA(0x0596, asm.ABS),   # C0ED9C:    STA $0596                     [8D 96 05]
+                                # Note: Lenophis skips "LDA #$01, STA $05C7" (see C0/BD06)
+                                # This is an efficiency, it's accomplished on line C08D0A.
+            asm.LDX(0x0003, asm.IMM16), # C0ED9F:    LDX  # $0003                  [A2 03 00]
+            asm.STX(0xe8, asm.DIR),     # C0EDA2:    STX $E8                       [86 E8]
+            asm.LDA(0x087c, asm.ABS_Y), # C0EDA4:    LDA $087C, Y                  [B9 7C 08]
+            asm.STA(0x087d, asm.ABS_Y), # C0EDA7:    STA $087D, Y                  [99 7D 08]
+            asm.LDA(0x04, asm.IMM8),    # C0EDAA:    LDA  # $04                    [A9 04]
+            asm.STA(0x087c, asm.ABS_Y), # C0EDAC:    STA $087C, Y                  [99 7C 08]
+            asm.JSR(0x7e08, asm.ABS),   # C0EDAF:    JSR $7E08 (jump to subroutine) [20 08 7E]
+            asm.JSR(0x2fed, asm.ABS),   # C0EDB2:    JSR $2FED                     [20 ED 2F]
+
+            asm.REP(0x20),              # C0EDB5:    REP  # $20                    [C2 20]
+            asm.BRA("DO_NORMAL_TRIGGERS")  # C0EDB7:    BRA C08CE8; do normal event triggers now  [80 AB]
+        ]
+
+        space = Write(Bank.C0, src, "Long event program code")
+
+        hook = Reserve(0x0bcaa, 0x0bcac, "Hook for long event program code", field.NOP())
+        hook.write(
+            asm.JSR(space.start_address, asm.ABS)
+        )
+
+        pointspace = Reserve(self.POINTER_START_ADDR_LONG, self.DATA_START_ADDR_LONG, 'Long Event Pointers', 0x0)
+
+        if self.verbose:
+            print('Added long event program at: ' + str(hex(space.start_address)) + ' -- ', str(hex(space.end_address)) )
+

--- a/data/maps.py
+++ b/data/maps.py
@@ -6,7 +6,7 @@ from data.npc import NPC
 from data.chests import Chests
 
 import data.map_events as events
-from data.map_event import MapEvent
+from data.map_event import MapEvent, LongMapEvent
 
 import data.map_exits as exits
 from data.map_exit import ShortMapExit, LongMapExit
@@ -18,6 +18,7 @@ class Maps():
     MAP_COUNT = 416
 
     EVENT_PTR_START = 0x40000
+    LONG_EVENT_PTR_START = events.LongMapEvents.POINTER_START_ADDR_LONG
     ENTRANCE_EVENTS_START_ADDR = 0x11fa00
 
     SHORT_EXIT_PTR_START = 0x1fbb00
@@ -32,6 +33,7 @@ class Maps():
         self.npcs = npcs.NPCs(rom)
         self.chests = Chests(self.rom, self.args, items)
         self.events = events.MapEvents(rom)
+        self.long_events = events.LongMapEvents(rom)
         self.exits = exits.MapExits(rom)
         self.world_map_event_modifications = world_map_event_modifications.WorldMapEventModifications(rom)
         self.world_map = WorldMap(rom, args)
@@ -55,6 +57,10 @@ class Maps():
             events_ptr_address = self.EVENT_PTR_START + map_index * self.rom.SHORT_PTR_SIZE
             events_ptr = self.rom.get_bytes(events_ptr_address, self.rom.SHORT_PTR_SIZE)
             self.maps[map_index]["events_ptr"] = events_ptr[0] | (events_ptr[1] << 8)
+
+            # LONG EVENTS INITIALIZATION: Vanilla code has no long events.
+            # Set initial offset to the vanilla value for each map.
+            self.maps[map_index]["long_events_ptr"] = self.maps[0]["events_ptr"]
 
             short_exit_ptr_address = self.SHORT_EXIT_PTR_START + map_index * self.rom.SHORT_PTR_SIZE
             short_exit_ptr = self.rom.get_bytes(short_exit_ptr_address, self.rom.SHORT_PTR_SIZE)
@@ -137,6 +143,41 @@ class Maps():
         last_event_id = first_event_id + self.get_event_count(map_id)
         self.events.delete_event(first_event_id, last_event_id, x, y)
 
+    ### LONG EVENTS ###
+    def get_long_event_count(self, map_id):
+        return (self.maps[map_id + 1]["long_events_ptr"] - self.maps[map_id][
+            "long_events_ptr"]) // LongMapEvent.DATA_SIZE
+
+    def print_long_events(self, map_id):
+        first_event_id = (self.maps[map_id]["long_events_ptr"] - self.maps[0][
+            "long_events_ptr"]) // LongMapEvent.DATA_SIZE
+
+        self.long_events.print_range(first_event_id, self.get_event_count(map_id))
+
+    def get_long_event(self, map_id, x, y):
+        first_event_id = (self.maps[map_id]["long_events_ptr"] - self.maps[0][
+            "long_events_ptr"]) // LongMapEvent.DATA_SIZE
+        last_event_id = first_event_id + self.get_event_count(map_id)
+        return self.long_events.get_event(first_event_id, last_event_id, x, y)
+
+    def add_long_event(self, map_id, new_event):
+        for map_index in range(map_id + 1, self.MAP_COUNT):
+            self.maps[map_index]["long_events_ptr"] += LongMapEvent.DATA_SIZE
+
+        event_id = (self.maps[map_id]["long_events_ptr"] - self.maps[0][
+            "long_events_ptr"]) // LongMapEvent.DATA_SIZE
+        self.long_events.add_event(event_id, new_event)
+
+    def delete_long_event(self, map_id, x, y):
+        for map_index in range(map_id + 1, self.MAP_COUNT):
+            self.maps[map_index]["long_events_ptr"] -= LongMapEvent.DATA_SIZE
+
+        first_event_id = (self.maps[map_id]["long_events_ptr"] - self.maps[0][
+            "long_events_ptr"]) // LongMapEvent.DATA_SIZE
+        last_event_id = first_event_id + self.get_event_count(map_id)
+        self.long_events.delete_event(first_event_id, last_event_id, x, y)
+    ### LONG EVENTS ###
+
     def get_short_exit_count(self, map_id):
         return (self.maps[map_id + 1]["short_exits_ptr"] - self.maps[map_id]["short_exits_ptr"]) // ShortMapExit.DATA_SIZE
 
@@ -188,17 +229,54 @@ class Maps():
         compressed = compress(decompressed)
         self.rom.set_bytes(tilemaps_start + tilemap_addr, compressed)
 
+    def _fix_Cid_timer_glitch(self):
+        from memory.space import Bank, Write
+        import instruction.field as field
+        from event.event import EVENT_CODE_START
+        # If you start Cid's timer and then leave, the timer can affect event tile, NPC and objective triggering
+        # Write some LongMapEvents to turn off the Cid timer when exiting to the world map.
+        HORIZ = 0
+        VERT = 128
+
+        # LONG EVENT #1: play the lore sound effect on some horizontal tiles on the Blackjack
+        src = [
+            field.BranchIfEventBitSet(0x1b5, "SetBit"),
+            field.ResetTimer(0),
+            field.SetEventBit(0x1b5),
+            "SetBit",
+            field.Return(),
+        ]
+        space = Write(Bank.CC, src, 'Reset Cid event timer')
+
+        map_id = 0x18c  # Cid's Island, Outside
+
+        new_event_data = [(16, 1, 14, VERT), (15, 1, 14, VERT),  # (x, y, length, direction)
+                          (0, 1, 14, VERT), (1, 1, 14, VERT),    # Include 2 layers to make sure it doesn't get skipped
+                          (0, 1, 3, HORIZ), (0, 2, 3, HORIZ),
+                          (7, 0, 2, HORIZ), (7, 1, 2, HORIZ),
+                          (12, 1, 3, HORIZ), (12, 2, 3, HORIZ)]
+        for i in range(len(new_event_data)):
+            new_le = LongMapEvent()
+            new_le.x = new_event_data[i][0]
+            new_le.y = new_event_data[i][1]
+            new_le.size = new_event_data[i][2]
+            new_le.direction = new_event_data[i][3]
+            new_le.event_address = space.start_address - EVENT_CODE_START
+            self.add_long_event(map_id, new_le)
+
     def mod(self, characters):
         self.npcs.mod(characters)
         self.chests.mod()
         self.world_map.mod()
 
         self._fix_imperial_camp_boxes()
+        self._fix_Cid_timer_glitch()
 
     def write(self):
         self.npcs.write()
         self.chests.write()
         self.events.write()
+        self.long_events.write()
         self.exits.write()
         self.world_map_event_modifications.write()
 
@@ -217,6 +295,13 @@ class Maps():
             events_ptr_bytes[0] = cur_map["events_ptr"] & 0xff
             events_ptr_bytes[1] = (cur_map["events_ptr"] & 0xff00) >> 8
             self.rom.set_bytes(events_ptr_start, events_ptr_bytes)
+
+            # LONG EVENTS
+            long_events_ptr_start = self.LONG_EVENT_PTR_START + cur_map["id"] * self.rom.SHORT_PTR_SIZE
+            long_events_ptr_bytes = [0x00] * self.rom.SHORT_PTR_SIZE
+            long_events_ptr_bytes[0] = cur_map["long_events_ptr"] & 0xff
+            long_events_ptr_bytes[1] = (cur_map["long_events_ptr"] & 0xff00) >> 8
+            self.rom.set_bytes(long_events_ptr_start, long_events_ptr_bytes)
 
             short_exits_ptr_start = self.SHORT_EXIT_PTR_START + cur_map["id"] * self.rom.SHORT_PTR_SIZE
             short_exits_bytes = [0x00] * self.rom.SHORT_PTR_SIZE


### PR DESCRIPTION
This code (1) adds Lenophis' long event tiles to WC as MapLongEvents, and (2) uses them to run an event script that stops Cid's health countdown timer when you take an exit from Cid's House, Outside (0x18c) to the world map.  This should prevent "door timer glitch"-style problems (missing event tile triggers, phasing through NPCs, etc.) when players start Cid's health countdown and then leave to do other things. 