### PR TITLE
Feature: Adding Auto Clear, Dark, and Imp objective results

### DIFF
--- a/battle/auto_status.py
+++ b/battle/auto_status.py
@@ -7,12 +7,15 @@ import objectives
 
 class _AutoStatus:
     def __init__(self):
+        auto_a_status_effects = ["Dark", "Clear", "Imp"]
         auto_b_status_effects = ["Condemned", "Image", "Mute", "Berserk", "Muddle", "Seizure", "Sleep"]
         auto_c_status_effects = ["Float", "Regen", "Slow", "Haste", "Shell", "Safe", "Reflect"]
         auto_d_status_effects = ["Life 3", "Dog Block"]
         auto_phantasm_overcast_status_effects = ["Overcast"]
 
         auto_addresses = []
+        for status in auto_a_status_effects:
+            auto_addresses.append(self.auto_status(status, status_effects.A))
         for status in auto_b_status_effects:
             auto_addresses.append(self.auto_status(status, status_effects.B))
         for status in auto_c_status_effects:
@@ -59,7 +62,10 @@ class _AutoStatus:
             status_bit = 1 << status_effects_group.name_id["Dance"]
         else:
             status_bit = 1 << status_effects_group.name_id[status_name]
-        if status_effects_group == status_effects.B:
+        if status_effects_group == status_effects.A:
+            status_address = 0x1614
+            opcode = asm.ABS_Y
+        elif status_effects_group == status_effects.B:
             status_address = 0x3c6c
             opcode = asm.ABS_X
         elif status_effects_group == status_effects.C:

--- a/constants/objectives/results.py
+++ b/constants/objectives/results.py
@@ -91,6 +91,9 @@ category_types["Item"].append(ResultType(60, "Sprint Shoes", "Sprint Shoes", Non
 category_types["Auto"].append(ResultType(61, "Auto Dog Block", "Auto Dog Block", None))
 category_types["Auto"].append(ResultType(62, "Auto Life 3", "Auto Life 3", None))
 category_types["Auto"].append(ResultType(63, "Auto Overcast", "Auto Overcast", None))
+category_types["Auto"].append(ResultType(64, "Auto Dark", "Auto Dark", None))
+category_types["Auto"].append(ResultType(65, "Auto Clear", "Auto Clear", None))
+category_types["Auto"].append(ResultType(66, "Auto Imp", "Auto Imp", None))
 
 categories = list(category_types.keys())
 

--- a/objectives/results/auto_clear.py
+++ b/objectives/results/auto_clear.py
@@ -1,0 +1,14 @@
+from objectives.results._objective_result import *
+
+class Field(field_result.Result):
+    def src(self):
+        return []
+
+class Battle(battle_result.Result):
+    def src(self):
+        return []
+
+class Result(ObjectiveResult):
+    NAME = "Auto Clear"
+    def __init__(self):
+        super().__init__(Field, Battle)

--- a/objectives/results/auto_dark.py
+++ b/objectives/results/auto_dark.py
@@ -1,0 +1,14 @@
+from objectives.results._objective_result import *
+
+class Field(field_result.Result):
+    def src(self):
+        return []
+
+class Battle(battle_result.Result):
+    def src(self):
+        return []
+
+class Result(ObjectiveResult):
+    NAME = "Auto Dark"
+    def __init__(self):
+        super().__init__(Field, Battle)

--- a/objectives/results/auto_imp.py
+++ b/objectives/results/auto_imp.py
@@ -1,0 +1,14 @@
+from objectives.results._objective_result import *
+
+class Field(field_result.Result):
+    def src(self):
+        return []
+
+class Battle(battle_result.Result):
+    def src(self):
+        return []
+
+class Result(ObjectiveResult):
+    NAME = "Auto Imp"
+    def __init__(self):
+        super().__init__(Field, Battle)


### PR DESCRIPTION
![auto_clear](https://github.com/ff6wc/WorldsCollide/assets/96998881/ec0ae5ce-78c4-483f-9af7-37703dcd275a)
![auto_dark](https://github.com/ff6wc/WorldsCollide/assets/96998881/856d3320-f6de-4fdc-bbbc-7fd3be89c964)
![auto_imp](https://github.com/ff6wc/WorldsCollide/assets/96998881/e2562f77-a8b3-408b-a81f-a8d7a0c54588)

Objective results 64 (dark), 65 (clear), and 66 (imp).

Tested with UL4 flags, appending `-oe 64.0.0`, `-oe 65.0.0`, or `-oe 66.0.0` to apply them from the start of the seed. 