### PR TITLE
Add BC's nicer poison mod to reduce pixellation while moving

### DIFF
--- a/args/graphics.py
+++ b/args/graphics.py
@@ -22,6 +22,9 @@ def parse(parser):
     graphics.add_argument("-ahtc", "--alternate-healing-text-color", action = "store_true",
                               help = "Makes healing text blue, to be able to distinguish from damage.")
 
+    graphics.add_argument("-lpb", "--less-poison-blur", action = "store_true",
+                             help = "Reduces pixellation while walking when poisoned.")
+
 def process(args):
     import graphics.palettes.palettes as palettes
     import graphics.portraits.portraits as portraits
@@ -118,6 +121,8 @@ def flags(args):
         flags += " -wmhc"
     if args.alternate_healing_text_color:
         flags += " -ahtc"
+    if args.less_poison_blur:
+        flags += " -lpb"
 
     return flags
 
@@ -191,6 +196,7 @@ def _other_options_log(args):
         ("Remove Flashes", remove_flashes),
         ("World Minimap", world_minimap),
         ("Healing Text", healing_text),
+        ("Less Poison Blur", args.less_poison_blur),
     ]
 
     for entry in entries:

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -3,6 +3,7 @@ from settings.movement import Movement
 from settings.random_rng import RandomRNG
 from settings.permadeath import Permadeath
 from settings.y_npc import YNPC
+from settings.less_poison_blur import LessPoisonBlur
 from settings.config import Config
 
 from memory.space import Reserve
@@ -16,6 +17,7 @@ class Settings:
         self.random_rng = RandomRNG()
         self.permadeath = Permadeath()
         self.y_npc = YNPC()
+        self.less_poison_blur = LessPoisonBlur()
         self.config = Config()
 
         # do not auto load save file after game over

--- a/settings/less_poison_blur.py
+++ b/settings/less_poison_blur.py
@@ -1,0 +1,28 @@
+## Original mod from Beyond Chaos
+## https://github.com/FF6BeyondChaos/BeyondChaosRandomizer/blob/main/BeyondChaos/patches.py
+## look for section beginning with "nicer_poison(fout):"
+from memory.space import Reserve
+import instruction.asm as asm
+import args
+
+### reduce poison pixellation effect while walking
+### does not affect poison sound effect while on overworld map
+class LessPoisonBlur:
+    def __init__(self):
+        if args.less_poison_blur:
+            self.mod()
+
+    def mod(self):
+        # make poison pixelation effect 1/10 of it's vanilla amount in dungeons/towns
+        space = Reserve(0x00e82, 0x00e9f, "town/dungeon poison gfx fix")
+        space.write(
+            [0x0F, 0x0F, 0x0F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F,
+             0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F,
+             0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0F, 0x0F, 0x0F]
+        )
+        
+        # remove poison pixelation on the overworld
+        space = Reserve(0x2e1864, 0x2e1865, "overworld poison gfx fix")
+        space.write(
+            asm.LDA(0x00, asm.IMM8),
+        )


### PR DESCRIPTION
Reduces pixellation while walking when poisoned to 1/10 while in towns/dungeons, and removes it completely while on the world map. Leaves the poison "heartbeat" sound effect while on the world map.

Screenshot of constant pixellation level:
![screenshot](https://github.com/ff6wc/WorldsCollide/assets/15148657/6951c4e8-7d65-4a67-bd71-711a36fe7ce8)
