### PR TITLE
Throwables and Restoratives objective results

### DIFF
--- a/args/espers.py
+++ b/args/espers.py
@@ -17,22 +17,28 @@ def parse(parser):
 
     esper_start = espers.add_mutually_exclusive_group()
     esper_start.add_argument("-stesp", "--starting-espers", default = [0, 0], type = int,
-                                nargs = 2, metavar = ("MIN", "MAX"), choices = range(MAX_STARTING_ESPERS + 1),
-                                help = "Party starts with %(metavar) random espers")
+                             nargs = 2, metavar = ("MIN", "MAX"), choices = range(MAX_STARTING_ESPERS + 1),
+                             help = "Party starts with %(metavar) random espers")
 
     esper_spells = espers.add_mutually_exclusive_group()
 
     esper_spells.add_argument("-esrr", "--esper-spells-random-rates", action = "store_true",
-                              help = "Original esper spells with random learn rates")
+                              help = "(DEPRECATED) Original esper spells with random learn rates")
     esper_spells.add_argument("-ess", "--esper-spells-shuffle", action = "store_true",
-                              help = "Esper spells shuffled with original learn rates")
+                              help = "Esper spells shuffled")
     esper_spells.add_argument("-essrr", "--esper-spells-shuffle-random-rates", action = "store_true",
-                              help = "Esper spells shuffled with random learn rates")
+                              help = "(DEPRECATED) Esper spells shuffled with random learn rates")
     esper_spells.add_argument("-esr", "--esper-spells-random", default = None, type = int,
                               nargs = 2, metavar = ("MIN", "MAX"), choices = range(Esper.SPELL_COUNT + 1),
-                              help = "Esper spells and learn rates randomized")
+                              help = "Esper spells randomized")
     esper_spells.add_argument("-esrt", "--esper-spells-random-tiered", action = "store_true",
-                              help = "Esper spells and learn rates randomized by tier")
+                              help = "Esper spells randomized by tier")
+
+    esper_learnrates = espers.add_mutually_exclusive_group()
+    esper_learnrates.add_argument("-elr", "--esper-learnrates-random", action = "store_true",
+                                  help = "Esper learn rates randomized")
+    esper_learnrates.add_argument("-elrt", "--esper-learnrates-random-tiered", action="store_true",
+                                  help="Esper learn rates randomized by tier")
 
     esper_bonuses = espers.add_mutually_exclusive_group()
     esper_bonuses.add_argument("-ebs", "--esper-bonuses-shuffle", action = "store_true",
@@ -74,6 +80,18 @@ def process(args):
     args._process_min_max("esper_mp_random_percent")
     args._process_min_max("esper_equipable_random")
 
+    # Forces random learnrates if espers are not original/shuffled and learnrates are not set to tiered
+    randomized_espers = args.esper_spells_random or args.esper_spells_random_tiered
+    if randomized_espers and args.esper_learnrates_random_tiered != True:
+        args.esper_learnrates_random = True
+
+    # Converts deprecated combined esper/learnrate flags to separate args
+    if args.esper_spells_random_rates:
+        args.esper_learnrates_random = True
+    elif args.esper_spells_shuffle_random_rates:
+        args.esper_spells_shuffle = True
+        args.esper_learnrates_random = True
+
     if args.esper_bonuses_random is not None:
         args.esper_bonuses_random_percent = args.esper_bonuses_random
         args.esper_bonuses_random = True
@@ -88,16 +106,17 @@ def flags(args):
     if args.starting_espers_min or args.starting_espers_max:
         flags += f" -stesp {args.starting_espers_min} {args.starting_espers_max}"
 
-    if args.esper_spells_random_rates:
-        flags += " -esrr"
-    elif args.esper_spells_shuffle:
+    if args.esper_spells_shuffle:
         flags += " -ess"
-    elif args.esper_spells_shuffle_random_rates:
-        flags += " -essrr"
     elif args.esper_spells_random:
         flags += f" -esr {args.esper_spells_random_min} {args.esper_spells_random_max}"
     elif args.esper_spells_random_tiered:
         flags += " -esrt"
+
+    if args.esper_learnrates_random:
+        flags += " -elr"
+    elif args.esper_learnrates_random_tiered:
+        flags += " -elrt"
 
     if args.esper_bonuses_shuffle:
         flags += " -ebs"
@@ -126,16 +145,18 @@ def flags(args):
 
 def options(args):
     spells = "Original"
-    if args.esper_spells_random_rates:
-        spells = "Original (Random Rates)"
-    elif args.esper_spells_shuffle:
+    if args.esper_spells_shuffle:
         spells = "Shuffle"
-    elif args.esper_spells_shuffle_random_rates:
-        spells = "Shuffle (Random Rates)"
     elif args.esper_spells_random:
         spells = f"Random {args.esper_spells_random_min}-{args.esper_spells_random_max}"
     elif args.esper_spells_random_tiered:
         spells = "Random Tiered"
+
+    learnrates = "Original"
+    if args.esper_learnrates_random:
+        learnrates = "Random"
+    elif args.esper_learnrates_random_tiered:
+        learnrates = "Random Tiered"
 
     bonuses = "Original"
     if args.esper_bonuses_shuffle:
@@ -160,6 +181,7 @@ def options(args):
     result = []
     result.append(("Starting Espers", f"{args.starting_espers_min}-{args.starting_espers_max}"))
     result.append(("Spells", spells))
+    result.append(("Rates", learnrates))
     result.append(("Bonuses", bonuses))
     if args.esper_bonuses_random:
         result.append(("Bonus Chance", f"{args.esper_bonuses_random_percent}%"))

--- a/constants/objectives/results.py
+++ b/constants/objectives/results.py
@@ -94,6 +94,8 @@ category_types["Auto"].append(ResultType(63, "Auto Overcast", "Auto Overcast", N
 category_types["Auto"].append(ResultType(64, "Auto Dark", "Auto Dark", None))
 category_types["Auto"].append(ResultType(65, "Auto Clear", "Auto Clear", None))
 category_types["Auto"].append(ResultType(66, "Auto Imp", "Auto Imp", None))
+category_types["Item"].append(ResultType(67, "Throwables", "Throwables", None))
+category_types["Item"].append(ResultType(68, "Restoratives", "Restoratives", None))
 
 categories = list(category_types.keys())
 

--- a/data/esper.py
+++ b/data/esper.py
@@ -131,6 +131,27 @@ class Esper(AbilityData):
         for spell_index in range(self.spell_count):
             self.spells[spell_index].rate = random.choice(self.LEARN_RATES)
 
+    def randomize_rates_tiered(self):
+        import random
+        from data.esper_spell_tiers import tiers
+        for spell_index in range(self.spell_count):
+            if self.spells[spell_index].id in tiers[0]:
+                self.spells[spell_index].rate = random.choice([10, 15, 16, 20])
+            elif self.spells[spell_index].id in tiers[1]:
+                self.spells[spell_index].rate = random.choice([5, 6, 7, 8])
+            elif self.spells[spell_index].id in tiers[2]:
+                self.spells[spell_index].rate = random.choice([1, 2, 3, 4])
+            elif self.spells[spell_index].id in tiers[3]:
+                self.spells[spell_index].rate = random.choice([10, 15, 16, 20])
+            elif self.spells[spell_index].id in tiers[4]:
+                self.spells[spell_index].rate = random.choice([6, 7, 8, 10, 15])
+            elif self.spells[spell_index].id in tiers[5]:
+                self.spells[spell_index].rate = random.choice([4, 5, 6, 7, 8])
+            elif self.spells[spell_index].id in tiers[6]:
+                self.spells[spell_index].rate = random.choice([2, 3, 4])
+            elif self.spells[spell_index].id in tiers[7]:
+                self.spells[spell_index].rate = 1
+
     def randomize_bonus(self):
         import random
         # exclude lvl percent bonuses

--- a/data/espers.py
+++ b/data/espers.py
@@ -172,6 +172,10 @@ class Espers():
         for esper in self.espers:
             esper.randomize_rates()
 
+    def randomize_rates_tiered(self):
+        for esper in self.espers:
+            esper.randomize_rates_tiered()
+
     def shuffle_bonuses(self):
         bonuses = []
         for esper in self.espers:
@@ -273,18 +277,18 @@ class Espers():
     def mod(self, dialogs):
         self.receive_dialogs_mod(dialogs)
 
-        if self.args.esper_spells_random_rates or self.args.esper_spells_shuffle_random_rates:
-            self.randomize_rates()
-
-        if len(self.starting_espers):
-            self.randomize_rates()
-
         if self.args.esper_spells_shuffle or self.args.esper_spells_shuffle_random_rates:
             self.shuffle_spells()
         elif self.args.esper_spells_random:
             self.randomize_spells()
         elif self.args.esper_spells_random_tiered:
             self.randomize_spells_tiered()
+
+        if self.args.esper_learnrates_random:
+            self.randomize_rates()
+
+        if self.args.esper_learnrates_random_tiered:
+            self.randomize_rates_tiered()
 
         if self.args.esper_bonuses_shuffle:
             self.shuffle_bonuses()
@@ -319,6 +323,7 @@ class Espers():
 
         if self.args.esper_multi_summon:
             self.multi_summon()
+
 
     def write(self):
         if self.args.spoiler_log:

--- a/objectives/results/restoratives.py
+++ b/objectives/results/restoratives.py
@@ -1,0 +1,37 @@
+from objectives.results._objective_result import *
+from data.item_names import name_id as item_name_id
+
+RESTORATIVES = ["Tonic", "Potion", "X-Potion", "Tincture", "Ether", "X-Ether", "Elixir", "Megalixir", "Fenix Down",
+                "Revivify", "Antidote", "Eyedrop", "Soft", "Remedy", "Sleeping Bag", "Tent", "Green Cherry",
+                "Echo Screen"]
+RESTORATIVE_COUNTS = [10, 10, 5, 10, 10, 5, 3, 1, 10, 5, 2, 2, 2, 3, 10, 3, 2, 2]
+RESTORATIVE_IDS = [item_name_id[item_name] for item_name in RESTORATIVES]
+
+
+class Field(field_result.Result):
+    def src(self):
+        src = []
+        for item_id, count in zip(RESTORATIVE_IDS, RESTORATIVE_COUNTS):
+            for _ in range(count):
+                src += [
+                    field.AddItem(item_id),
+                ]
+        return src
+
+
+class Battle(battle_result.Result):
+    def src(self):
+        src = []
+        for item_id, count in zip(RESTORATIVE_IDS, RESTORATIVE_COUNTS):
+            for _ in range(count):
+                src += [
+                    battle_result.AddItem(item_id),
+                ]
+        return src
+
+
+class Result(ObjectiveResult):
+    NAME = "Restoratives"
+
+    def __init__(self):
+        super().__init__(Field, Battle)

--- a/objectives/results/throwables.py
+++ b/objectives/results/throwables.py
@@ -1,0 +1,36 @@
+from objectives.results._objective_result import *
+from data.item_names import name_id as item_name_id
+
+THROWABLES = ["Shuriken", "Ninja Star", "Tack Star", "Fire Skean", "Water Edge", "Bolt Edge", "Inviz Edge",
+              "Shadow Edge"]
+THROWABLE_COUNTS = [20, 10, 5, 10, 10, 10, 5, 5]
+THROWABLE_IDS = [item_name_id[item_name] for item_name in THROWABLES]
+
+
+class Field(field_result.Result):
+    def src(self):
+        src = []
+        for item_id, count in zip(THROWABLE_IDS, THROWABLE_COUNTS):
+            for _ in range(count):
+                src += [
+                    field.AddItem(item_id),
+                ]
+        return src
+
+
+class Battle(battle_result.Result):
+    def src(self):
+        src = []
+        for item_id, count in zip(THROWABLE_IDS, THROWABLE_COUNTS):
+            for _ in range(count):
+                src += [
+                    battle_result.AddItem(item_id),
+                ]
+        return src
+
+
+class Result(ObjectiveResult):
+    NAME = "Throwables"
+
+    def __init__(self):
+        super().__init__(Field, Battle)


### PR DESCRIPTION
Added objective results 67 ("Throwables") and 68 ("Restoratives").

Throwables adds the following to the player's inventory:

|    Item     | Count |
|-------------|-------|
| Shuriken    |    20 |
| Ninja Star  |    10 |
| Tack Star   |     5 |
| Fire Skean  |    10 |
| Water Edge  |    10 |
| Bolt Edge   |    10 |
| Inviz Edge  |     5 |
| Shadow Edge |     5 |

Restoratives adds the following to the player's inventory:

|     Item     | Count |
|--------------|-------|
| Tonic        |    10 |
| Potion       |    10 |
| X-Potion     |     5 |
| Tincture     |    10 |
| Ether        |    10 |
| X-Ether      |     5 |
| Elixir       |     3 |
| Megalixir    |     1 |
| Fenix Down   |    10 |
| Revivify     |     5 |
| Antidote     |     2 |
| Eyedrop      |     2 |
| Soft         |     2 |
| Remedy       |     3 |
| Sleeping Bag |    10 |
| Tent         |     3 |
| Green Cherry |     2 |
| Echo Screen  |     2 |

**Throwables:**
![ffiii_wc_slx1a8vcpvm9000](https://github.com/ff6wc/WorldsCollide/assets/45882117/b113f7dd-1a99-4449-bcee-1959bf776c75)

![ffiii_wc_slx1a8vcpvm9001](https://github.com/ff6wc/WorldsCollide/assets/45882117/1afe92fa-a450-4d4f-9691-c1febe03c8c6)

![ffiii_wc_slx1a8vcpvm9002](https://github.com/ff6wc/WorldsCollide/assets/45882117/4d630228-3151-42df-adbb-0f5c395eb3a9)

**Restoratives:**
![ffiii_wc_vadcag6u052e000](https://github.com/ff6wc/WorldsCollide/assets/45882117/75d23f04-9246-475c-9e93-79826f86ae4a)

![ffiii_wc_vadcag6u052e001](https://github.com/ff6wc/WorldsCollide/assets/45882117/f2c195d0-8599-43bb-8dae-1ff125777292)

![ffiii_wc_vadcag6u052e002](https://github.com/ff6wc/WorldsCollide/assets/45882117/fbec68b4-b96b-4669-945f-56e12aa669a4)
