### PR TITLE
Split esper spells flags into separate flags for spells and learnrate…

### DIFF
--- a/args/espers.py
+++ b/args/espers.py
@@ -17,22 +17,28 @@ def parse(parser):
 
     esper_start = espers.add_mutually_exclusive_group()
     esper_start.add_argument("-stesp", "--starting-espers", default = [0, 0], type = int,
-                                nargs = 2, metavar = ("MIN", "MAX"), choices = range(MAX_STARTING_ESPERS + 1),
-                                help = "Party starts with %(metavar) random espers")
+                             nargs = 2, metavar = ("MIN", "MAX"), choices = range(MAX_STARTING_ESPERS + 1),
+                             help = "Party starts with %(metavar) random espers")
 
     esper_spells = espers.add_mutually_exclusive_group()
 
     esper_spells.add_argument("-esrr", "--esper-spells-random-rates", action = "store_true",
-                              help = "Original esper spells with random learn rates")
+                              help = "(DEPRECATED) Original esper spells with random learn rates")
     esper_spells.add_argument("-ess", "--esper-spells-shuffle", action = "store_true",
-                              help = "Esper spells shuffled with original learn rates")
+                              help = "Esper spells shuffled")
     esper_spells.add_argument("-essrr", "--esper-spells-shuffle-random-rates", action = "store_true",
-                              help = "Esper spells shuffled with random learn rates")
+                              help = "(DEPRECATED) Esper spells shuffled with random learn rates")
     esper_spells.add_argument("-esr", "--esper-spells-random", default = None, type = int,
                               nargs = 2, metavar = ("MIN", "MAX"), choices = range(Esper.SPELL_COUNT + 1),
-                              help = "Esper spells and learn rates randomized")
+                              help = "Esper spells randomized")
     esper_spells.add_argument("-esrt", "--esper-spells-random-tiered", action = "store_true",
-                              help = "Esper spells and learn rates randomized by tier")
+                              help = "Esper spells randomized by tier")
+
+    esper_learnrates = espers.add_mutually_exclusive_group()
+    esper_learnrates.add_argument("-elr", "--esper-learnrates-random", action = "store_true",
+                                  help = "Esper learn rates randomized")
+    esper_learnrates.add_argument("-elrt", "--esper-learnrates-random-tiered", action="store_true",
+                                  help="Esper learn rates randomized by tier")
 
     esper_bonuses = espers.add_mutually_exclusive_group()
     esper_bonuses.add_argument("-ebs", "--esper-bonuses-shuffle", action = "store_true",
@@ -74,6 +80,18 @@ def process(args):
     args._process_min_max("esper_mp_random_percent")
     args._process_min_max("esper_equipable_random")
 
+    # Forces random learnrates if espers are not original/shuffled and learnrates are not set to tiered
+    randomized_espers = args.esper_spells_random or args.esper_spells_random_tiered
+    if randomized_espers and args.esper_learnrates_random_tiered != True:
+        args.esper_learnrates_random = True
+
+    # Converts deprecated combined esper/learnrate flags to separate args
+    if args.esper_spells_random_rates:
+        args.esper_learnrates_random = True
+    elif args.esper_spells_shuffle_random_rates:
+        args.esper_spells_shuffle = True
+        args.esper_learnrates_random = True
+
     if args.esper_bonuses_random is not None:
         args.esper_bonuses_random_percent = args.esper_bonuses_random
         args.esper_bonuses_random = True
@@ -88,16 +106,17 @@ def flags(args):
     if args.starting_espers_min or args.starting_espers_max:
         flags += f" -stesp {args.starting_espers_min} {args.starting_espers_max}"
 
-    if args.esper_spells_random_rates:
-        flags += " -esrr"
-    elif args.esper_spells_shuffle:
+    if args.esper_spells_shuffle:
         flags += " -ess"
-    elif args.esper_spells_shuffle_random_rates:
-        flags += " -essrr"
     elif args.esper_spells_random:
         flags += f" -esr {args.esper_spells_random_min} {args.esper_spells_random_max}"
     elif args.esper_spells_random_tiered:
         flags += " -esrt"
+
+    if args.esper_learnrates_random:
+        flags += " -elr"
+    elif args.esper_learnrates_random_tiered:
+        flags += " -elrt"
 
     if args.esper_bonuses_shuffle:
         flags += " -ebs"
@@ -126,16 +145,18 @@ def flags(args):
 
 def options(args):
     spells = "Original"
-    if args.esper_spells_random_rates:
-        spells = "Original (Random Rates)"
-    elif args.esper_spells_shuffle:
+    if args.esper_spells_shuffle:
         spells = "Shuffle"
-    elif args.esper_spells_shuffle_random_rates:
-        spells = "Shuffle (Random Rates)"
     elif args.esper_spells_random:
         spells = f"Random {args.esper_spells_random_min}-{args.esper_spells_random_max}"
     elif args.esper_spells_random_tiered:
         spells = "Random Tiered"
+
+    learnrates = "Original"
+    if args.esper_learnrates_random:
+        learnrates = "Random"
+    elif args.esper_learnrates_random_tiered:
+        learnrates = "Random Tiered"
 
     bonuses = "Original"
     if args.esper_bonuses_shuffle:
@@ -160,6 +181,7 @@ def options(args):
     result = []
     result.append(("Starting Espers", f"{args.starting_espers_min}-{args.starting_espers_max}"))
     result.append(("Spells", spells))
+    result.append(("Rates", learnrates))
     result.append(("Bonuses", bonuses))
     if args.esper_bonuses_random:
         result.append(("Bonus Chance", f"{args.esper_bonuses_random_percent}%"))

--- a/data/esper.py
+++ b/data/esper.py
@@ -131,6 +131,27 @@ class Esper(AbilityData):
         for spell_index in range(self.spell_count):
             self.spells[spell_index].rate = random.choice(self.LEARN_RATES)
 
+    def randomize_rates_tiered(self):
+        import random
+        from data.esper_spell_tiers import tiers
+        for spell_index in range(self.spell_count):
+            if self.spells[spell_index].id in tiers[0]:
+                self.spells[spell_index].rate = random.choice([10, 15, 16, 20])
+            elif self.spells[spell_index].id in tiers[1]:
+                self.spells[spell_index].rate = random.choice([5, 6, 7, 8])
+            elif self.spells[spell_index].id in tiers[2]:
+                self.spells[spell_index].rate = random.choice([1, 2, 3, 4])
+            elif self.spells[spell_index].id in tiers[3]:
+                self.spells[spell_index].rate = random.choice([10, 15, 16, 20])
+            elif self.spells[spell_index].id in tiers[4]:
+                self.spells[spell_index].rate = random.choice([6, 7, 8, 10, 15])
+            elif self.spells[spell_index].id in tiers[5]:
+                self.spells[spell_index].rate = random.choice([4, 5, 6, 7, 8])
+            elif self.spells[spell_index].id in tiers[6]:
+                self.spells[spell_index].rate = random.choice([2, 3, 4])
+            elif self.spells[spell_index].id in tiers[7]:
+                self.spells[spell_index].rate = 1
+
     def randomize_bonus(self):
         import random
         # exclude lvl percent bonuses

--- a/data/espers.py
+++ b/data/espers.py
@@ -172,6 +172,10 @@ class Espers():
         for esper in self.espers:
             esper.randomize_rates()
 
+    def randomize_rates_tiered(self):
+        for esper in self.espers:
+            esper.randomize_rates_tiered()
+
     def shuffle_bonuses(self):
         bonuses = []
         for esper in self.espers:
@@ -273,18 +277,18 @@ class Espers():
     def mod(self, dialogs):
         self.receive_dialogs_mod(dialogs)
 
-        if self.args.esper_spells_random_rates or self.args.esper_spells_shuffle_random_rates:
-            self.randomize_rates()
-
-        if len(self.starting_espers):
-            self.randomize_rates()
-
         if self.args.esper_spells_shuffle or self.args.esper_spells_shuffle_random_rates:
             self.shuffle_spells()
         elif self.args.esper_spells_random:
             self.randomize_spells()
         elif self.args.esper_spells_random_tiered:
             self.randomize_spells_tiered()
+
+        if self.args.esper_learnrates_random:
+            self.randomize_rates()
+
+        if self.args.esper_learnrates_random_tiered:
+            self.randomize_rates_tiered()
 
         if self.args.esper_bonuses_shuffle:
             self.shuffle_bonuses()
@@ -319,6 +323,7 @@ class Espers():
 
         if self.args.esper_multi_summon:
             self.multi_summon()
+
 
     def write(self):
         if self.args.spoiler_log:

--- a/data/espers.py
+++ b/data/espers.py
@@ -284,6 +284,13 @@ class Espers():
         elif self.args.esper_spells_random_tiered:
             self.randomize_spells_tiered()
 
+        if self.args.esper_spells_random or self.args.esper_spells_random_tiered:
+            # if random, replace the spells
+            self.replace_flagged_learnables()
+        else:
+            # otherwise (original or shuffled), remove them
+            self.remove_flagged_learnables()
+
         if self.args.esper_learnrates_random:
             self.randomize_rates()
 
@@ -313,13 +320,6 @@ class Espers():
 
         if self.args.permadeath:
             self.phoenix_life3()
-
-        if self.args.esper_spells_random or self.args.esper_spells_random_tiered:
-            # if random, replace the spells
-            self.replace_flagged_learnables()
-        else:
-            # otherwise (original or shuffled), remove them
-            self.remove_flagged_learnables()
 
         if self.args.esper_multi_summon:
             self.multi_summon()


### PR DESCRIPTION
### Overview

Currently, the Esper Spells flags control both the spells taught by espers and their learn rates. This change breaks these two functions into separate flags, while adding a new Random Tiered option for learn rates. Two existing flag settings are deprecated but remain backwards compatible with existing flagstrings.

### Esper Spells

Options for esper spells are:
**Original** `(blank)` - Espers teach their original spells.
**Shuffle** `-ess` - Original esper spells are randomly assigned to espers using a uniform distribution. The number of spells each esper teaches is unmodified.
**Random Tiered** `-esrt` - Esper spells are categorized by tier and chosen at random. Higher tier spells are less likely to be chosen. The number of spells each esper teaches is randomly selected using a uniform distribution.
**Random** `-esr` - Esper spells are chosen at random using a uniform distribution. The number of spells each esper teaches is randomly selected within the given range using a uniform distribution.

Options for esper learn rates are:
**Original** `(blank)` - Espers teach spells at their original rates. Important note: If espers are randomized, learn rates will instead be set to _Random_.
**Random** `-elr` - Esper spell learn rates are randomly assigned using a uniform distribution.
**Random Tiered** `-elrt` - Esper spells are categorized by tier, and spell learn rates are randomly assigned from a range of options specific to each tier:

| Spell Tier | Learnrate Range |
|------------|-----------------|
| G          | 10x - 20x       |
| F          | 5x - 8x         |
| E          | 1x - 4x         |
| D          | 10x - 20x       |
| C          | 6x - 15x        |
| B          | 4x - 8x         |
| A          | 2x - 4x         |
| S          | 1x - 1x         |

For reference, spell tiers are found [here](https://wiki.ff6worldscollide.com/wiki/Flags:EsperSpellTiers).

### Deprecated flags
**Original (Random Rates)** `-esrr` - Functionally equivalent to Original spells (no flag), Random learn rates (`-elr`).
**Shuffle (Random Rates)** `-essrr` - Functionally equivalent to Shuffled spells (`-ess`), Random learn rates (`-elr`).

Backwards compatibility is in place for both of the above - flagstrings including either of these flags are converted to the appropriate combination of updated flags, and the output file will reflect the updated flagstring.

![ffiii_wc_s8gpsgev2f53000](https://github.com/ff6wc/WorldsCollide/assets/45882117/ece55b09-2f11-423a-8bee-4b8cd8d50a2f)

![ffiii_wc_ofb9kwo6wo9v000](https://github.com/ff6wc/WorldsCollide/assets/45882117/783ceb42-1b61-4426-b1b0-83754840a5a6)

