### PR TITLE
Update events.py

### DIFF
--- a/event/events.py
+++ b/event/events.py
@@ -171,4 +171,4 @@ class Events():
         for event in events:
             char_esper_checks += [r for r in event.rewards if r.possible_types == (RewardType.CHARACTER | RewardType.ESPER)]
 
-        assert len(char_esper_checks) == CHARACTER_ESPER_ONLY_REWARDS, "Number of char/esper only checks changed - Check usages of CHARACTER_ESPER_ONLY_REWARDS and ensure no breaking changes"
+        f"Number of char/esper only checks changed - Check usages of CHARACTER_ESPER_ONLY_REWARDS and ensure no breaking changes. Expected: {CHARACTER_ESPER_ONLY_REWARDS}, Actual: {len(char_esper_checks)}"


### PR DESCRIPTION
Added a improved error message, now tells you exactly what the expected count of char/esper only rewards are compared to what the actual number are. Previously this was a hard-coded value used for comparison that wasn't expressed in the comment.