### PR TITLE
Added flag to customize list of potential item rewards from checks

### DIFF
--- a/args/items.py
+++ b/args/items.py
@@ -82,33 +82,33 @@ def process(args):
 
     args.item_rewards_ids = []
 
-    if args.item_rewards:
-        # Split the comma-separated string
-        for a_item_id in args.item_rewards.split(','):
-            # look for strings first
-            a_item_id = a_item_id.lower().strip()
-            if a_item_id == 'standard':
-                args.item_rewards_ids = [name_id[name] for name in good_items]
-            elif a_item_id == 'premium':
-                args.item_rewards_ids = [name_id[name] for name in better_items]
+    if not args.item_rewards:
+        args.item_rewards = 'standard'
+
+    # Split the comma-separated string
+    for a_item_id in args.item_rewards.split(','):
+        # look for strings first
+        a_item_id = a_item_id.lower().strip()
+        if a_item_id == 'standard':
+            args.item_rewards_ids = [name_id[name] for name in good_items]
+        elif a_item_id == 'premium':
+            args.item_rewards_ids = [name_id[name] for name in better_items]
+        else:
+            item_ids_lower = {k.lower(): v for k, v in name_id.items()}
+            if a_item_id in item_ids_lower:
+                args.item_rewards_ids.append(item_ids_lower[a_item_id])
             else:
-                item_ids_lower = {k.lower(): v for k, v in name_id.items()}
-                if a_item_id in item_ids_lower:
-                    args.item_rewards_ids.append(item_ids_lower[a_item_id])
-                else:
-                    # assuming it's a number... it'll error out if not
-                    args.item_rewards_ids.append(int(a_item_id))
-    else:
-        args.item_rewards_ids = [name_id[name] for name in good_items]
+                # assuming it's a number... it'll error out if not
+                args.item_rewards_ids.append(int(a_item_id))
 
     # remove duplicates and sort
     args.item_rewards_ids = list(set(args.item_rewards_ids))
     args.item_rewards_ids.sort()
 
     # Remove Atma Weapon is it's not Stronger and we're in standard/premium
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids and args.item_rewards:
-        if any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
-            args.item_rewards_ids.remove(name_id["Atma Weapon"])
+    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids \
+       and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
+        args.item_rewards_ids.remove(name_id["Atma Weapon"])
 
     # Remove excluded items
     if args.no_free_paladin_shields and name_id["Paladin Shld"] in args.item_rewards_ids:

--- a/args/items.py
+++ b/args/items.py
@@ -98,16 +98,19 @@ def process(args):
                 else:
                     # assuming it's a number... it'll error out if not
                     args.item_rewards_ids.append(int(a_item_id))
-        # remove duplicates and sort
     else:
         args.item_rewards_ids = [name_id[name] for name in good_items]
 
+    # remove duplicates and sort
     args.item_rewards_ids = list(set(args.item_rewards_ids))
     args.item_rewards_ids.sort()
 
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids \
-            and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
-        args.item_rewards_ids.remove(name_id["Atma Weapon"])
+    # Remove Atma Weapon is it's not Stronger and we're in standard/premium
+    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids and args.item_rewards:
+        if any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
+            args.item_rewards_ids.remove(name_id["Atma Weapon"])
+
+    # Remove excluded items
     if args.no_free_paladin_shields and name_id["Paladin Shld"] in args.item_rewards_ids:
         args.item_rewards_ids.remove(name_id["Paladin Shld"])
     if args.no_exp_eggs and name_id["Exp. Egg"] in args.item_rewards_ids:

--- a/args/items.py
+++ b/args/items.py
@@ -1,57 +1,57 @@
 def name():
     return "Items"
 
+
 def parse(parser):
     from data.characters import Characters
     items = parser.add_argument_group("Items")
 
     items_equipable = items.add_mutually_exclusive_group()
     items_equipable.add_argument("-ier", "--item-equipable-random",
-                                 default = None, type = int, nargs = 2, metavar = ("MIN", "MAX"),
-                                 choices = range(Characters.CHARACTER_COUNT + 1),
-                                 help = "Each item equipable by between %(metavar)s random characters")
+                                 default=None, type=int, nargs=2, metavar=("MIN", "MAX"),
+                                 choices=range(Characters.CHARACTER_COUNT + 1),
+                                 help="Each item equipable by between %(metavar)s random characters")
     items_equipable.add_argument("-iebr", "--item-equipable-balanced-random",
-                                 default = None, type = int, metavar = "VALUE",
-                                 choices = range(Characters.CHARACTER_COUNT + 1),
-                                 help = "Each item equipable by %(metavar)s random characters. Total number of items equipable by each character is balanced")
+                                 default=None, type=int, metavar="VALUE",
+                                 choices=range(Characters.CHARACTER_COUNT + 1),
+                                 help="Each item equipable by %(metavar)s random characters. Total number of items equipable by each character is balanced")
     items_equipable.add_argument("-ieor", "--item-equipable-original-random",
-                                 default = None, type = int, metavar = "PERCENT", choices = range(-100, 101),
-                                 help = "Characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
+                                 default=None, type=int, metavar="PERCENT", choices=range(-100, 101),
+                                 help="Characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
     items_equipable.add_argument("-iesr", "--item-equipable-shuffle-random",
-                                 default = None, type = int, metavar = "PERCENT", choices = range(-100, 101),
-                                 help = "Shuffle character equipment. After randomization, characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
+                                 default=None, type=int, metavar="PERCENT", choices=range(-100, 101),
+                                 help="Shuffle character equipment. After randomization, characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
 
     items_equipable_relic = items.add_mutually_exclusive_group()
     items_equipable_relic.add_argument("-ierr", "--item-equipable-relic-random",
-                                       default = None, type = int, nargs = 2, metavar = ("MIN", "MAX"),
-                                       choices = range(Characters.CHARACTER_COUNT + 1),
-                                       help = "Each relic equipable by between %(metavar)s random characters")
+                                       default=None, type=int, nargs=2, metavar=("MIN", "MAX"),
+                                       choices=range(Characters.CHARACTER_COUNT + 1),
+                                       help="Each relic equipable by between %(metavar)s random characters")
     items_equipable_relic.add_argument("-ierbr", "--item-equipable-relic-balanced-random",
-                                       default = None, type = int, metavar = "VALUE",
-                                       choices = range(Characters.CHARACTER_COUNT + 1),
-                                       help = "Each relic equipable by %(metavar)s random characters. Total number of relics equipable by each character is balanced")
+                                       default=None, type=int, metavar="VALUE",
+                                       choices=range(Characters.CHARACTER_COUNT + 1),
+                                       help="Each relic equipable by %(metavar)s random characters. Total number of relics equipable by each character is balanced")
     items_equipable_relic.add_argument("-ieror", "--item-equipable-relic-original-random",
-                                       default = None, type = int, metavar = "PERCENT", choices = range(-100, 101),
-                                       help = "Characters have a %(metavar)s chance of being able to equip each relic they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each relic they could previously equip")
+                                       default=None, type=int, metavar="PERCENT", choices=range(-100, 101),
+                                       help="Characters have a %(metavar)s chance of being able to equip each relic they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each relic they could previously equip")
     items_equipable_relic.add_argument("-iersr", "--item-equipable-relic-shuffle-random",
-                                       default = None, type = int, metavar = "PERCENT", choices = range(-100, 101),
-                                       help = "Shuffle character relics. After randomization, characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
+                                       default=None, type=int, metavar="PERCENT", choices=range(-100, 101),
+                                       help="Shuffle character relics. After randomization, characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
 
-    items.add_argument("-ir", "--item-rewards", type = str,
-                       help = "Choose which items will be received as check rewards")
+    items.add_argument("-ir", "--item-rewards", type=str,
+                       help="Choose which items will be received as check rewards")
 
-    items.add_argument("-csb", "--cursed-shield-battles", default = [256, 256], type = int,
-                       nargs = 2, metavar = ("MIN", "MAX"), choices = range(257),
-                       help = "Number of battles required to uncurse the cursed shield")
+    items.add_argument("-csb", "--cursed-shield-battles", default=[256, 256], type=int,
+                       nargs=2, metavar=("MIN", "MAX"), choices=range(257),
+                       help="Number of battles required to uncurse the cursed shield")
 
-    items.add_argument("-mca", "--moogle-charm-all", action = "store_true",
-                       help = "All characters can wear Moogle Charm relics which prevent random battles. Overrides Equipable option")
-    items.add_argument("-stra", "--swdtech-runic-all", action = "store_true",
-                       help = "All weapons enable swdtech and runic")
+    items.add_argument("-mca", "--moogle-charm-all", action="store_true",
+                       help="All characters can wear Moogle Charm relics which prevent random battles. Overrides Equipable option")
+    items.add_argument("-stra", "--swdtech-runic-all", action="store_true",
+                       help="All weapons enable swdtech and runic")
 
-    items.add_argument("-saw", "--stronger-atma-weapon", action = "store_true",
-                       help = "Atma Weapon moved to higher tier and divisor reduced from 64 to 32")
-
+    items.add_argument("-saw", "--stronger-atma-weapon", action="store_true",
+                       help="Atma Weapon moved to higher tier and divisor reduced from 64 to 32")
 
 
 def process(args):
@@ -105,7 +105,8 @@ def process(args):
     args.item_rewards_ids = list(set(args.item_rewards_ids))
     args.item_rewards_ids.sort()
 
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids:
+    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids \
+            and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
         args.item_rewards_ids.remove(name_id["Atma Weapon"])
     if args.no_free_paladin_shields and name_id["Paladin Shld"] in args.item_rewards_ids:
         args.item_rewards_ids.remove(name_id["Paladin Shld"])
@@ -115,8 +116,9 @@ def process(args):
         args.item_rewards_ids.remove(name_id["Illumina"])
 
     args._process_min_max("cursed_shield_battles")
-    args.cursed_shield_battles_original = args.cursed_shield_battles_min == 256 and\
+    args.cursed_shield_battles_original = args.cursed_shield_battles_min == 256 and \
                                           args.cursed_shield_battles_max == 256
+
 
 def flags(args):
     flags = ""
@@ -155,6 +157,7 @@ def flags(args):
 
     return flags
 
+
 def options(args):
     equipable = "Original"
     if args.item_equipable_random:
@@ -188,12 +191,14 @@ def options(args):
         ("Item Rewards", args.item_rewards_ids),
     ]
 
+
 def _format_items_log_entries(item_ids):
     from constants.items import id_name
     item_entries = []
     for item_id in item_ids:
         item_entries.append(("", id_name[item_id]))
     return item_entries
+
 
 def menu(args):
     from menus.flags_reward_items import FlagsRewardItems
@@ -218,6 +223,7 @@ def menu(args):
             pass
 
     return (name(), entries)
+
 
 def log(args):
     from log import format_option

--- a/args/items.py
+++ b/args/items.py
@@ -55,7 +55,7 @@ def parse(parser):
 
 
 def process(args):
-    from constants.items import good_items, better_items
+    from constants.items import good_items, stronger_items, premium_items
     from constants.items import id_name, name_id
 
     args._process_min_max("item_equipable_random")
@@ -89,10 +89,14 @@ def process(args):
     for a_item_id in args.item_rewards.split(','):
         # look for strings first
         a_item_id = a_item_id.lower().strip()
-        if a_item_id == 'standard':
+        if a_item_id == 'none':
+            args.item_rewards_ids = []
+        elif a_item_id == 'standard':
             args.item_rewards_ids = [name_id[name] for name in good_items]
+        elif a_item_id == 'stronger':
+            args.item_rewards_ids = [name_id[name] for name in stronger_items]
         elif a_item_id == 'premium':
-            args.item_rewards_ids = [name_id[name] for name in better_items]
+            args.item_rewards_ids = [name_id[name] for name in premium_items]
         else:
             item_ids_lower = {k.lower(): v for k, v in name_id.items()}
             if a_item_id in item_ids_lower:
@@ -107,7 +111,7 @@ def process(args):
 
     # Remove Atma Weapon is it's not Stronger and we're in standard/premium
     if not args.stronger_atma_weapon and name_id["Atma Weapon"] in args.item_rewards_ids \
-       and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard', 'premium')):
+       and any(s.lower().strip() in args.item_rewards.split(',') for s in ('none', 'standard', 'stronger', 'premium')):
         args.item_rewards_ids.remove(name_id["Atma Weapon"])
 
     # Remove excluded items

--- a/args/items.py
+++ b/args/items.py
@@ -115,6 +115,11 @@ def process(args):
     if args.no_illuminas and name_id["Illumina"] in args.item_rewards_ids:
         args.item_rewards_ids.remove(name_id["Illumina"])
 
+    # Make dead checks award "empty" if the item reward list is empty (e.g. all items were supposed to be Illuminas and
+    # the No Illumina flag is on)
+    if len(args.item_rewards_ids) < 1:
+        args.item_rewards_ids.append(name_id["Empty"])
+
     args._process_min_max("cursed_shield_battles")
     args.cursed_shield_battles_original = args.cursed_shield_battles_min == 256 and \
                                           args.cursed_shield_battles_max == 256

--- a/args/items.py
+++ b/args/items.py
@@ -114,6 +114,10 @@ def process(args):
         args.item_rewards_ids.remove(name_id["Exp. Egg"])
     if args.no_illuminas and name_id["Illumina"] in args.item_rewards_ids:
         args.item_rewards_ids.remove(name_id["Illumina"])
+    if args.no_sprint_shoes and name_id["Sprint Shoes"] in args.item_rewards_ids:
+        args.item_rewards_ids.remove(name_id["Sprint Shoes"])
+    if args.no_moogle_charms and name_id["Moogle Charm"] in args.item_rewards_ids:
+        args.item_rewards_ids.remove(name_id["Moogle Charm"])
 
     # Make dead checks award "empty" if the item reward list is empty (e.g. all items were supposed to be Illuminas and
     # the No Illumina flag is on)

--- a/constants/items.py
+++ b/constants/items.py
@@ -268,6 +268,7 @@ good_items = [
     "ValiantKnife",
     "Illumina",
     "Ragnarok",
+    "Atma Weapon",
     "Pearl Lance",
     "Aura Lance",
     "Magus Rod",
@@ -293,6 +294,22 @@ good_items = [
     "Gem Box",
     "Dragon Horn",
     "Marvel Shoes",
+    "Exp. Egg",
+]
+
+better_items = [
+    "ValiantKnife",
+    "Illumina",
+    "Ragnarok",
+    "Atma Weapon",
+    "Fixed Dice",
+    "Flame Shld",
+    "Ice Shld",
+    "Thunder Shld",
+    "Paladin Shld",
+    "Minerva",
+    "Genji Glove",
+    "Offering",
     "Exp. Egg",
 ]
 

--- a/constants/items.py
+++ b/constants/items.py
@@ -3,6 +3,24 @@ EMPTY = 0xff
 
 BREAKABLE_RODS = range(53, 59)
 ELEMENTAL_SHIELDS = range(96, 99)
+DIRKS = range(0, 10)
+SWORDS = range(10, 29)
+LANCES = range(29, 37)
+KNIVES = range(37, 43)
+KATANAS = range(43, 51)
+RODS = range(51, 61)
+BRUSHES = range(61, 65)
+STARS = range(65, 68)
+SPECIAL = range(68, 77)
+GAMBLER = range(77, 83)
+CLAWS = range(83, 90)
+SHIELDS = range(90, 105)
+HELMETS = range(105, 132)
+ARMORS = range(132, 163)
+TOOLS = range(163, 171)
+SKEANS = range(171, 176)
+RELICS = range(176, 231)
+
 
 id_name = {
     0   : "Dirk",

--- a/constants/items.py
+++ b/constants/items.py
@@ -315,7 +315,30 @@ good_items = [
     "Exp. Egg",
 ]
 
-better_items = [
+stronger_items = [
+    "ValiantKnife",
+    "Illumina",
+    "Ragnarok",
+    "Atma Weapon",
+    "Aura Lance",
+    "Fixed Dice",
+    "Flame Shld",
+    "Ice Shld",
+    "Thunder Shld",
+    "Paladin Shld",
+    "Force Shld",
+    "Cat Hood",
+    "Force Armor",
+    "Minerva",
+    "BehemothSuit",
+    "Snow Muffler",
+    "Genji Glove",
+    "Offering",
+    "Dragon Horn",
+    "Exp. Egg",
+]
+
+premium_items = [
     "ValiantKnife",
     "Illumina",
     "Ragnarok",

--- a/data/items.py
+++ b/data/items.py
@@ -2,7 +2,7 @@ import args, random
 from data.item import Item
 from data.structures import DataList
 
-from constants.items import good_items, better_items
+from constants.items import good_items, stronger_items, premium_items
 from constants.items import id_name, name_id
 
 import data.items_asm as items_asm

--- a/data/items.py
+++ b/data/items.py
@@ -58,6 +58,10 @@ class Items():
         GOOD.remove(name_id["Exp. Egg"])
     if args.no_illuminas and name_id["Illumina"] in GOOD:
         GOOD.remove(name_id["Illumina"])
+    if args.no_sprint_shoes and name_id["Sprint Shoes"] in GOOD:
+        GOOD.remove(name_id["Sprint Shoes"])
+    if args.no_moogle_charms and name_id["Moogle Charm"] in GOOD:
+        GOOD.remove(name_id["Moogle Charm"])
 
     # Make dead checks award "empty" if the item reward list is empty (e.g. all items were supposed to be Illuminas and
     # the No Illumina flag is on)

--- a/data/items.py
+++ b/data/items.py
@@ -2,7 +2,7 @@ import args, random
 from data.item import Item
 from data.structures import DataList
 
-from constants.items import good_items
+from constants.items import good_items, better_items
 from constants.items import id_name, name_id
 
 import data.items_asm as items_asm
@@ -21,15 +21,35 @@ class Items():
     DESC_START = 0x2d6400
     DESC_END = 0x2d779f
 
-    GOOD = [name_id[name] for name in good_items]
-    if args.stronger_atma_weapon:
-        GOOD.append(name_id["Atma Weapon"])
-    if args.no_free_paladin_shields:
-        GOOD.remove(name_id["Paladin Shld"])
-    if args.no_exp_eggs:
-        GOOD.remove(name_id["Exp. Egg"])
-    if args.no_illuminas:
-        GOOD.remove(name_id["Illumina"])
+    'process high tier items here'
+    args.item_rewards_ids = []
+
+    if args.item_rewards:
+        # Split the comma-separated string
+        for a_item_id in args.item_rewards.split(','):
+            # look for strings first
+            a_item_id = a_item_id.lower().strip()
+            if a_item_id == 'standard':
+                args.item_rewards_ids = [name_id[name] for name in good_items]
+            elif a_item_id == 'premium':
+                args.item_rewards_ids = [name_id[name] for name in better_items]
+            else:
+                item_ids_lower = {k.lower(): v for k, v in name_id.items()}
+                if a_item_id in item_ids_lower:
+                    args.item_rewards_ids.append(item_ids_lower[a_item_id])
+                else:
+                    # assuming it's a number... it'll error out if not
+                    args.item_rewards_ids.append(int(a_item_id))
+        # remove duplicates and sort
+    else:
+        args.item_rewards_ids = [name_id[name] for name in good_items]
+
+    args.item_rewards_ids = list(set(args.item_rewards_ids))
+    args.item_rewards_ids.sort()
+
+    GOOD = args.item_rewards_ids
+
+    1
 
     def __init__(self, rom, args, dialogs, characters):
         self.rom = rom

--- a/data/items.py
+++ b/data/items.py
@@ -49,7 +49,15 @@ class Items():
 
     GOOD = args.item_rewards_ids
 
-    1
+    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in GOOD \
+            and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard','premium')):
+        GOOD.remove(name_id["Atma Weapon"])
+    if args.no_free_paladin_shields and name_id["Paladin Shld"] in GOOD:
+        GOOD.remove(name_id["Paladin Shld"])
+    if args.no_exp_eggs and name_id["Exp. Egg"] in GOOD:
+        GOOD.remove(name_id["Exp. Egg"])
+    if args.no_illuminas and name_id["Illumina"] in GOOD:
+        GOOD.remove(name_id["Illumina"])
 
     def __init__(self, rom, args, dialogs, characters):
         self.rom = rom

--- a/data/items.py
+++ b/data/items.py
@@ -21,52 +21,7 @@ class Items():
     DESC_START = 0x2d6400
     DESC_END = 0x2d779f
 
-    'process high tier items here'
-    args.item_rewards_ids = []
-
-    if args.item_rewards:
-        # Split the comma-separated string
-        for a_item_id in args.item_rewards.split(','):
-            # look for strings first
-            a_item_id = a_item_id.lower().strip()
-            if a_item_id == 'standard':
-                args.item_rewards_ids = [name_id[name] for name in good_items]
-            elif a_item_id == 'premium':
-                args.item_rewards_ids = [name_id[name] for name in better_items]
-            else:
-                item_ids_lower = {k.lower(): v for k, v in name_id.items()}
-                if a_item_id in item_ids_lower:
-                    args.item_rewards_ids.append(item_ids_lower[a_item_id])
-                else:
-                    # assuming it's a number... it'll error out if not
-                    args.item_rewards_ids.append(int(a_item_id))
-        # remove duplicates and sort
-    else:
-        args.item_rewards_ids = [name_id[name] for name in good_items]
-
-    args.item_rewards_ids = list(set(args.item_rewards_ids))
-    args.item_rewards_ids.sort()
-
     GOOD = args.item_rewards_ids
-
-    if not args.stronger_atma_weapon and name_id["Atma Weapon"] in GOOD \
-            and any(s.lower().strip() in args.item_rewards.split(',') for s in ('standard','premium')):
-        GOOD.remove(name_id["Atma Weapon"])
-    if args.no_free_paladin_shields and name_id["Paladin Shld"] in GOOD:
-        GOOD.remove(name_id["Paladin Shld"])
-    if args.no_exp_eggs and name_id["Exp. Egg"] in GOOD:
-        GOOD.remove(name_id["Exp. Egg"])
-    if args.no_illuminas and name_id["Illumina"] in GOOD:
-        GOOD.remove(name_id["Illumina"])
-    if args.no_sprint_shoes and name_id["Sprint Shoes"] in GOOD:
-        GOOD.remove(name_id["Sprint Shoes"])
-    if args.no_moogle_charms and name_id["Moogle Charm"] in GOOD:
-        GOOD.remove(name_id["Moogle Charm"])
-
-    # Make dead checks award "empty" if the item reward list is empty (e.g. all items were supposed to be Illuminas and
-    # the No Illumina flag is on)
-    if len(GOOD) < 1:
-        GOOD.append(name_id["Empty"])
 
     def __init__(self, rom, args, dialogs, characters):
         self.rom = rom

--- a/data/items.py
+++ b/data/items.py
@@ -59,6 +59,11 @@ class Items():
     if args.no_illuminas and name_id["Illumina"] in GOOD:
         GOOD.remove(name_id["Illumina"])
 
+    # Make dead checks award "empty" if the item reward list is empty (e.g. all items were supposed to be Illuminas and
+    # the No Illumina flag is on)
+    if len(GOOD) < 1:
+        GOOD.append(name_id["Empty"])
+
     def __init__(self, rom, args, dialogs, characters):
         self.rom = rom
         self.args = args

--- a/data/text/text2.py
+++ b/data/text/text2.py
@@ -27,7 +27,7 @@ text_value = {
               '<dirk icon>'         : 0xd8,
               '<sword icon>'        : 0xd9,
               '<lance icon>'        : 0xda,
-              '<knife icon>'        : 0xdb,
+              '<katana icon>'       : 0xdb,
               '<rod icon>'          : 0xdc,
               '<brush icon>'        : 0xdd,
               '<stars icon>'        : 0xde,

--- a/menus/flags_reward_items.py
+++ b/menus/flags_reward_items.py
@@ -1,0 +1,52 @@
+import menus.pregame_track_scroll_area as scroll_area
+from data.text.text2 import text_value
+import instruction.f0 as f0
+
+class FlagsRewardItems(scroll_area.ScrollArea):
+    MENU_NUMBER = 16
+
+    def __init__(self, item_ids):
+        self.number_items = len(item_ids)
+        self.lines = []
+
+        self.lines.append(scroll_area.Line(f"Item Rewards ({self.number_items})", f0.set_blue_text_color))
+        self.lines.append(scroll_area.Line(f"Checks may reward any of:", f0.set_gray_text_color))
+
+        item_lines = FlagsRewardItems._format_items_menu(item_ids)
+
+        for list_value in item_lines:
+            padding = scroll_area.WIDTH - (len(list_value))
+            self.lines.append(scroll_area.Line(f"{' ' * padding}{list_value}", f0.set_user_text_color))
+
+        super().__init__()
+
+    def _format_items_menu(item_ids):
+        from constants.items import id_name
+        COLUMN_WIDTHS = [13, 12]
+        item_lines = []
+
+        # Step through each spell by the number of columns
+        for item_idx in range(0, len(item_ids), len(COLUMN_WIDTHS)):
+            current_line = ''
+            # Populate each column on the line
+            for col in range(0, len(COLUMN_WIDTHS)):
+                if(item_idx + col < len(item_ids)):
+                    a_item_id = item_ids[item_idx + col]
+                    icon = FlagsRewardItems._get_item_icon(a_item_id)
+                    item_str = f"{icon}{id_name[a_item_id]}"
+                    padding = COLUMN_WIDTHS[col] - len(item_str)
+                    current_line += f"{item_str}{' ' * padding}"
+                else:
+                    # No spell, add padding
+                    current_line += f"{' ' * COLUMN_WIDTHS[col]}"
+            # Write the line
+            item_lines.append(current_line)
+        return item_lines
+
+    def _get_item_icon(item_id):
+        from constants.spells import black_magic_ids, gray_magic_ids, white_magic_ids
+        from data.text.text2 import text_value
+        icon = ''
+        # Potentially this could be used to get the appropriate icon for each item type using the same code from
+        # the remove learnable spells menu class
+        return icon

--- a/menus/flags_reward_items.py
+++ b/menus/flags_reward_items.py
@@ -22,10 +22,10 @@ class FlagsRewardItems(scroll_area.ScrollArea):
 
     def _format_items_menu(item_ids):
         from constants.items import id_name
-        COLUMN_WIDTHS = [13, 12]
+        COLUMN_WIDTHS = [13, 13]
         item_lines = []
 
-        # Step through each spell by the number of columns
+        # Step through each item by the number of columns
         for item_idx in range(0, len(item_ids), len(COLUMN_WIDTHS)):
             current_line = ''
             # Populate each column on the line
@@ -37,16 +37,49 @@ class FlagsRewardItems(scroll_area.ScrollArea):
                     padding = COLUMN_WIDTHS[col] - len(item_str)
                     current_line += f"{item_str}{' ' * padding}"
                 else:
-                    # No spell, add padding
+                    # No item, add padding
                     current_line += f"{' ' * COLUMN_WIDTHS[col]}"
             # Write the line
             item_lines.append(current_line)
         return item_lines
 
     def _get_item_icon(item_id):
-        from constants.spells import black_magic_ids, gray_magic_ids, white_magic_ids
+        from constants.items import DIRKS, SWORDS, LANCES, KNIVES, KATANAS, RODS, BRUSHES, \
+            STARS, SPECIAL, GAMBLER, CLAWS, SHIELDS, HELMETS, ARMORS, TOOLS, SKEANS, RELICS
         from data.text.text2 import text_value
         icon = ''
-        # Potentially this could be used to get the appropriate icon for each item type using the same code from
-        # the remove learnable spells menu class
+        if item_id in DIRKS or item_id in KNIVES:
+            icon = chr(text_value['<dirk icon>'])
+        elif item_id in SWORDS:
+            icon = chr(text_value['<sword icon>'])
+        elif item_id in LANCES:
+            icon = chr(text_value['<lance icon>'])
+        elif item_id in KATANAS:
+            icon = chr(text_value['<katana icon>'])
+        elif item_id in RODS:
+            # for some reason, the Rod icon causes submenus to not work
+            icon = ''
+            #icon = chr(text_value['<rod icon'])
+        elif item_id in BRUSHES:
+            icon = chr(text_value['<brush icon>'])
+        elif item_id in STARS:
+            icon = chr(text_value['<stars icon'])
+        elif item_id in SPECIAL:
+            icon = chr(text_value['<special icon>'])
+        elif item_id in GAMBLER:
+            icon = chr(text_value['<gambler icon>'])
+        elif item_id in CLAWS:
+            icon = chr(text_value['<claw icon>'])
+        elif item_id in SHIELDS:
+            icon = chr(text_value['<shield icon>'])
+        elif item_id in HELMETS:
+            icon = chr(text_value['<helmet icon>'])
+        elif item_id in ARMORS:
+            icon = chr(text_value['<armor icon>'])
+        elif item_id in TOOLS:
+            icon = chr(text_value['<tool icon>'])
+        elif item_id in SKEANS:
+            icon = chr(text_value['<skean icon>'])
+        elif item_id in RELICS:
+            icon = chr(text_value['<relic icon>'])
         return icon


### PR DESCRIPTION
# Overview

Currently, item rewards from non-progression checks (dead checks) are assigned randomly from a hard coded list of "good items." This change adds a new flag which allows the user to choose from several hard coded preset lists or to submit a custom list of item indexes which will be drawn from for non-progression check rewards. 

A submenu has been added to the Flags menu which lists potential item rewards for the seed.

## Item Rewards
The flag for this option is `-ir`

Current options for item rewards are:
**None** - `-ir none` - Checks that would reward an item reward nothing ("Empty") instead
**Standard** `-ir standard` - The existing list of item rewards from previous versions of Worlds Collide is used (see below)
**Stronger** - `ir stronger` - A smaller list of item rewards created by removing some weaker items from the standard list is used (see below)
**Premium** `-ir premium` - A much smaller list of item rewards created by removing all weaker items from the standard list is used (see below)
**Custom** `-ir (comma-separated list of up to 45 comma-separated integers corresponding to WC's item indices)` - The provided list of items will be used for all item rewards

### Standard Reward List

"ValiantKnife",	"Illumina",	"Ragnarok",	"Atma Weapon",	"Pearl Lance",	"Aura Lance",	"Magus Rod",	"Fixed Dice",	"Aegis Shld",	"Flame Shld",	"Ice Shld",	"Thunder Shld",	"Genji Shld",	"Paladin Shld",	"Force Shld",	"Red Cap",	"Cat Hood",	"Genji Helmet",	"Force Armor",	"Genji Armor",	"Minerva",	"BehemothSuit",	"Snow Muffler",	"Economizer",	"Genji Glove",	"Offering",	"Gem Box",	"Dragon Horn",	"Marvel Shoes",	"Exp. Egg"

### Stronger Reward List

"ValiantKnife",	"Illumina",	"Ragnarok",	"Atma Weapon",	"Aura Lance",	"Fixed Dice",	"Flame Shld",	"Ice Shld",	"Thunder Shld",	"Paladin Shld",	"Force Shld",	"Cat Hood",	"Force Armor",	"Minerva",	"BehemothSuit",	"Snow Muffler",	"Genji Glove",	"Offering",	"Dragon Horn",	"Exp. Egg"

### Premium Reward List

"ValiantKnife",	"Illumina",	"Ragnarok",	"Atma Weapon",	"Fixed Dice",	"Flame Shld",	"Ice Shld",	"Thunder Shld",	"Paladin Shld",	"Minerva",	"Genji Glove",	"Offering",	"Exp. Egg"

### Notes

- For the above lists, Atma Weapon is removed from these lists if the Stronger Atma Weapon is disabled. 
- For both preset and custom lists, Paladin Shld/Illumina/Exp Egg/Sprint Shoes/Moogle Charms are removed from lists if the flag removing that respective item from check rewards is enabled. For example, if the `-nil` flag is enabled, Illuminas will be not be found as a check reward, even if specifically listed in a custom Item Reward list.

## Testing/Demo

For each demo, the rewards from the 8 dragons are used to illustrate the rewards

### Test 1 - Standard Rewards
`py wc.py -i ffiii.smc -open -sl -ir standard`

Spoiler log shows item rewards drawn from the Standard reward list have been used.

> 8 Dragons                      Minerva, ValiantKnife, Snow Muffler, Flame Shld, Aura Lance, Economizer, Snow Muffler, BehemothSuit

### Test 2 - Premium Rewards
`py wc.py -i ffiii.smc -open -sl -ir premium`

Spoiler log shows item rewards drawn from the Premium reward list have been used.

> 8 Dragons                      Paladin Shld, Flame Shld, Ragnarok, ValiantKnife, Illumina, Minerva, Illumina, Flame Shld

### Test 3 - Custom List
`py wc.py -i ffiii.smc -open -sl -ir 82,211`

Spoiler log shows item rewards drawn from the two listed items have been used.

> 8 Dragons                      Fixed Dice, Fixed Dice, Offering, Offering, Fixed Dice, Fixed Dice, Offering, Offering

### Test 4 - Conflict resolution between opposing restriction flag and custom list
`py wc.py -i ffiii.smc -open -sl -ir 26 -nil`

Spoiler log shows item rewards as Empty (as intended, since Illumina was the only item selected and the No Illumina flag was set).

> 8 Dragons                      Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty

## Screenshots
![ffiii_wc_f4qcgrqfppl4001](https://github.com/ff6wc/WorldsCollide/assets/45882117/3ab578e1-37c1-4f19-ba16-17d74233c38a)
![ffiii_wc_f4qcgrqfppl4002](https://github.com/ff6wc/WorldsCollide/assets/45882117/6b71c134-acd4-4d47-a465-a65006a205cb)
![ffiii_wc_b9onbgrnj7lf000](https://github.com/ff6wc/WorldsCollide/assets/45882117/eab70b18-d0ff-417a-a6bf-ae94bd131d64)
![ffiii_wc_b9onbgrnj7lf001](https://github.com/ff6wc/WorldsCollide/assets/45882117/f0ef9391-0407-418e-a94b-4cd23976d337)

