### PR TITLE
Added flags for tiered equipable equipment and tiered equipable relics

### DIFF
--- a/args/items.py
+++ b/args/items.py
@@ -14,6 +14,8 @@ def parse(parser):
                                  default = None, type = int, metavar = "VALUE",
                                  choices = range(Characters.CHARACTER_COUNT + 1),
                                  help = "Each item equipable by %(metavar)s random characters. Total number of items equipable by each character is balanced")
+    items_equipable.add_argument("-ietr", "--item-equipable-tiered-random",action = "store_true",
+                                 help = "Equipment is categorized by tier and chance of being equipable by a character is chosen at random. Higher tier equipment is less likely to be equipable.")
     items_equipable.add_argument("-ieor", "--item-equipable-original-random",
                                  default = None, type = int, metavar = "PERCENT", choices = range(-100, 101),
                                  help = "Characters have a %(metavar)s chance of being able to equip each item they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each item they could previously equip")
@@ -30,6 +32,8 @@ def parse(parser):
                                        default = None, type = int, metavar = "VALUE",
                                        choices = range(Characters.CHARACTER_COUNT + 1),
                                        help = "Each relic equipable by %(metavar)s random characters. Total number of relics equipable by each character is balanced")
+    items_equipable_relic.add_argument("-iertr", "--item-equipable-relic-tiered-random", action="store_true",
+                                       help="Relics are categorized by tier and chance of being equipable by a character is chosen at random. Higher tier relics are less likely to be equipable.")
     items_equipable_relic.add_argument("-ieror", "--item-equipable-relic-original-random",
                                        default = None, type = int, metavar = "PERCENT", choices = range(-100, 101),
                                        help = "Characters have a %(metavar)s chance of being able to equip each relic they could not previously equip. If %(metavar)s negative, characters have a -%(metavar)s chance of not being able to equip each relic they could previously equip")
@@ -85,6 +89,8 @@ def flags(args):
         flags += f" -ier {args.item_equipable_random_min} {args.item_equipable_random_max}"
     elif args.item_equipable_balanced_random:
         flags += f" -iebr {args.item_equipable_balanced_random_value}"
+    elif args.item_equipable_tiered_random:
+        flags += f" -ietr"
     elif args.item_equipable_original_random:
         flags += f" -ieor {args.item_equipable_original_random_percent}"
     elif args.item_equipable_shuffle_random:
@@ -94,6 +100,8 @@ def flags(args):
         flags += f" -ierr {args.item_equipable_relic_random_min} {args.item_equipable_relic_random_max}"
     elif args.item_equipable_relic_balanced_random:
         flags += f" -ierbr {args.item_equipable_relic_balanced_random_value}"
+    elif args.item_equipable_relic_tiered_random:
+        flags += f" -iertr"
     elif args.item_equipable_relic_original_random:
         flags += f" -ieror {args.item_equipable_relic_original_random_percent}"
     elif args.item_equipable_relic_shuffle_random:
@@ -119,6 +127,8 @@ def options(args):
         equipable = f"Random {args.item_equipable_random_min}-{args.item_equipable_random_max}"
     elif args.item_equipable_balanced_random:
         equipable = f"Balanced Random {args.item_equipable_balanced_random_value}"
+    elif args.item_equipable_tiered_random:
+        equipable = f"Tiered Random"
     elif args.item_equipable_original_random:
         equipable = f"Original + Random {args.item_equipable_original_random_percent}%"
     elif args.item_equipable_shuffle_random:
@@ -129,6 +139,8 @@ def options(args):
         equipable_relics = f"Random {args.item_equipable_relic_random_min}-{args.item_equipable_relic_random_max}"
     elif args.item_equipable_relic_balanced_random:
         equipable_relics = f"Balanced Random {args.item_equipable_relic_balanced_random_value}"
+    elif args.item_equipable_relic_tiered_random:
+        equipable_relics = f"Tiered Random"
     elif args.item_equipable_relic_original_random:
         equipable_relics = f"Original + Random {args.item_equipable_relic_original_random_percent}%"
     elif args.item_equipable_relic_shuffle_random:
@@ -157,6 +169,7 @@ def menu(args):
             elif key == "Cursed Shield Battles":
                 key = "Cursed Shield"
             value = value.replace("Balanced Random", "Balanced")
+            value = value.replace("Tiered Random", "Tiered")
             value = value.replace("Original + Random", "Original + ")
             value = value.replace("Shuffle + Random", "Shuffle + ")
             entries[index] = (key, value)

--- a/data/items.py
+++ b/data/items.py
@@ -109,7 +109,7 @@ class Items():
         tier_maxes = [14, 12, 10, 6, 3]
 
         for item in self.items:
-            if item.is_equipable() and item.id != self.EMPTY and type_condition(item.type):
+            if item.is_equipable() and item.id != self.EMPTY and item.id != 102 and type_condition(item.type):
                 for i, tier in enumerate(tiers):
                     if item.id in tier:
                         item_tier = i - 5
@@ -121,6 +121,8 @@ class Items():
                 rand_chars = random.sample(self.characters.playable, num_chars)
                 for character in rand_chars:
                     item.add_equipable_character(character)
+        # force Cursed Shld equips to match Paladin Shld equips
+        self.items[102].equipable_characters = self.items[103].equipable_characters
 
     def equipable_original_random(self, type_condition, percent):
         if percent == 0:

--- a/data/items.py
+++ b/data/items.py
@@ -119,8 +119,14 @@ class Items():
 
                 num_chars = random.randint(tier_mins[item_tier], tier_maxes[item_tier])
                 rand_chars = random.sample(self.characters.playable, num_chars)
+
+                # if Paladin Shld is only equipable by Gogo and/or Umaro, instead reroll for 3 characters
+                if item.id == 103 and all(obj.id in [13, 14] for obj in rand_chars):
+                    rand_chars = random.sample(self.characters.playable, 3)
+
                 for character in rand_chars:
                     item.add_equipable_character(character)
+
         # force Cursed Shld equips to match Paladin Shld equips
         self.items[102].equipable_characters = self.items[103].equipable_characters
 


### PR DESCRIPTION
# Overview

This flag adds an additional option to the Equipable Items flags for Equipment and Relics to randomly assign a number of characters to be eligible to equip the respective item. Eligibility is determined by tiers aligned with power level and vanilla rarity - common, weaker items are typically equipable by most or all characters, while the strongest items are typically equipable by very few characters.

## Flags

`-ietr` - Equipment is categorized by tier and chance of being equipable by a character is chosen at random. Higher tier equipment is less likely to be equipable.

`-iertr` - Relics are categorized by tier and chance of being equipable by a character is chosen at random. Higher tier relics are less likely to be equipable.

Note: This flag does not replace or deprecate any existing flags, and no changes beyond the new functionality have been made to any other flags.

## Tiering and Weights

Tiering is drawn from the Chest Item Tiers list ([see wiki](https://wiki.ff6worldscollide.com/wiki/Flags:ChestItemTiers)). 

The range of characters that can equip is listed below. For illustrative purposes, a rough estimate is also provided of how likely a given character in a seed will be to equip a given item in that tier, as well as some examples of items in that tier.

<html><body>
<!--StartFragment--><google-sheets-html-origin>

Tier | Eligible Chars per Seed | Chance to equip | Weapon | Armor | Shield | Helm | Relic
-- | -- | -- | -- | -- | -- | -- | --
**S** | **1-4** | 17.9% | Illumina | Minerva | Paladin Shld | Cat Hood | Offering
**A** | **4-7** | 39.3% | Magus Rod | BehemothSuit | Thunder Shld | Genji Helmet | Genji Glove
**B** | **7-10** | 60.7% | Sky Render | Mirage Vest | Force Shld | Red Cap | Atlas Armlet
**C** | **10-13** | 82.1% | Flame Sabre | White Dress | Crystal Shld | Green Beret | Cursed Ring
**D** | **13-14** | 96.4% | Dirk | Gold Armor | Heavy Shld | Bandana | Goggles

<!--EndFragment-->
</body>
</html>

## Cursed Shld

As Cursed Shld is not included in the tiering list, Cursed Shld equipment permissions are set to match the Paladin Shld's permissions (e.g. if only Sabin and Cyan can equip the Paladin Shld, then only Sabin and Cyan can equip the Cursed Shld).

Additional code is present to prevent scenarios where the Paladin/Cursed Shld is only equipable by Gogo/Umaro to avoid situations where the Cursed Shld cannot be decursed.

## Testing

`-cg -sl -oa 40.0.0 -ob 38.0.0 -oc 42.0.0 -od 58.0.0 -oe 58.0.0 -of 58.0.0 -og 58.0.0 -oh 58.0.0 -oi 58.0.0 -oj 58.0.0 -ok 58.0.0 -ol 58.0.0 -om 58.0.0 -on 58.0.0 -oo 58.0.0 -op 58.0.0 -oq 58.0.0 -or 58.0.0 -os 58.0.0 -ot 58.0.0 -ou 58.0.0 -ov 58.0.0 -ow 58.0.0 -ox 58.0.0 -oy 58.0.0 -sc1 random -sc2 random -sc3 random -sc4 random -ietr -iertr -mca -smc 3 -gp 500000`

**S-tier**
Illumina - Equipable by 1 character
Offering - Equipable by 3 characters

**A-tier**
Magus Rod - equipable by 5 characters
Genji Glove - equipable by 6 characters

**B-tier**
Sky Render - equipable by 7 characters
Atlas Armlet - equipable by 9 characters

**C-tier**
Flame Sabre - equipable by 12 characters
Cursed Ring - equipable by 11 characters

**D-tier**
Dirk - equipable by 13 characters
Goggles - equipable by 14 characters


