### PR TITLE
Deprecate "Randomize Clock (-rc)" flag

### DIFF
--- a/args/misc.py
+++ b/args/misc.py
@@ -11,7 +11,7 @@ def parse(parser):
     misc.add_argument("-rr", "--random-rng", action = "store_true",
                       help = "Randomize in-game RNG table. Affects Setzer's Slots, Auction House, Ebot's Rock, ...")
     misc.add_argument("-rc", "--random-clock", action = "store_true",
-                      help = "Randomize clock's correct time and NPC clues in Zozo")
+                      help = "(DEPRECATED) Randomize clock's correct time and NPC clues in Zozo")
     misc.add_argument("-scan", "--scan-all", action = "store_true",
                       help = "All enemies scannable. All characters start with scan learned. Scan costs 0 MP. Useful for testing/debugging")
     misc.add_argument("-warp", "--warp-all", action = "store_true",
@@ -75,8 +75,6 @@ def flags(args):
         flags += " -ond"
     if args.random_rng:
         flags += " -rr"
-    if args.random_clock:
-        flags += " -rc"
     if args.scan_all:
         flags += " -scan"
     if args.warp_all:
@@ -156,7 +154,6 @@ def options(args):
         ("Movement", movement),
         ("Original Name Display", args.original_name_display),
         ("Random RNG", args.random_rng),
-        ("Random Clock", args.random_clock),
         ("Scan All", args.scan_all),
         ("Warp All", args.warp_all),
         ("Event Timers", event_timers),

--- a/event/zozo.py
+++ b/event/zozo.py
@@ -47,9 +47,8 @@ class Zozo(Event):
         self.log_reward(self.reward)
 
         self.set_clock_mod()
-        if self.args.random_clock:
-            time = self.randomize_clock_mod()
-            self.log_change("6:10:50", time)
+        time = self.randomize_clock_mod()
+        self.log_change("6:10:50", time)
 
     def add_gating_condition(self):
         src = [


### PR DESCRIPTION
The "Randomized Clock" flag (`-rc`) is removed, with the Zozo clock randomization instead added as baseline WC functionality.

Flagstrings which include the `-rc` flag will be accepted by the parser but the `-rc` flag will be ignored.

Note: There is no reverse compatibility here with previous flagsets that did not randomize the Zozo clock, however it is assumed that most, if not all, flagsets that included clock-related objectives also opted to randomize the clock, and that the clock's randomization on flagsets without clock-related objectives was irrelevant. Therefore the impact of this change is expected to be minimal or non-existent.