### PR TITLE
Deprecate "Random RNG (-rr)" flag

### DIFF
--- a/args/misc.py
+++ b/args/misc.py
@@ -9,7 +9,7 @@ def parse(parser):
     misc.add_argument("-ond", "--original-name-display", action = "store_true",
                       help = "Display original character names in party and party select menus")
     misc.add_argument("-rr", "--random-rng", action = "store_true",
-                      help = "Randomize in-game RNG table. Affects Setzer's Slots, Auction House, Ebot's Rock, ...")
+                      help = "(DEPRECATED) Randomize in-game RNG table. Affects Setzer's Slots, Auction House, Ebot's Rock, ...")
     misc.add_argument("-rc", "--random-clock", action = "store_true",
                       help = "Randomize clock's correct time and NPC clues in Zozo")
     misc.add_argument("-scan", "--scan-all", action = "store_true",
@@ -73,8 +73,6 @@ def flags(args):
         flags += f" -move {args.movement}"
     if args.original_name_display:
         flags += " -ond"
-    if args.random_rng:
-        flags += " -rr"
     if args.random_clock:
         flags += " -rc"
     if args.scan_all:
@@ -155,7 +153,6 @@ def options(args):
     return [
         ("Movement", movement),
         ("Original Name Display", args.original_name_display),
-        ("Random RNG", args.random_rng),
         ("Random Clock", args.random_clock),
         ("Scan All", args.scan_all),
         ("Warp All", args.warp_all),

--- a/settings/random_rng.py
+++ b/settings/random_rng.py
@@ -4,8 +4,7 @@ import args
 
 class RandomRNG:
     def __init__(self):
-        if args.random_rng:
-            self.mod()
+        self.mod()
 
     def mod(self):
         import random


### PR DESCRIPTION
The "Random RNG" flag (`-rr`) is removed, with RNG table randomization added as baseline WC functionality.

Flagstrings which include the `-rr` flag will be accepted by the parser but the `-rr` flag will be ignored.

Note: There is no reverse compatibility here with previous flagsets that did not randomize the RNG table. That said, the vast majority of seeds rolled used this flag. Disabling this flag was a very highly niche use case, and as such, no or minimal impact is anticipated to functionality of existing flagsets.
