### PR TITLE
Fixing bug where multiple items can be received from PT reward

### DIFF
--- a/event/phantom_train.py
+++ b/event/phantom_train.py
@@ -82,6 +82,7 @@ class PhantomTrain(Event):
             esper_item_instructions,
 
             field.HideEntity(ghost_npc_id),
+            field.RefreshEntities(),
             field.SetEventBit(event_bit.GOT_PHANTOM_TRAIN_REWARD),
             field.FinishCheck(),
             field.Return(),
@@ -100,6 +101,7 @@ class PhantomTrain(Event):
         space.write(
             field.ReturnIfEventBitClear(event_bit.GOT_PHANTOM_TRAIN_REWARD),
             field.HideEntity(ghost_npc_id),
+            field.RefreshEntities(),
             field.Return(),
         )
         self.maps.set_entrance_event(0x98, inside_last_car_entrance_event - EVENT_CODE_START)


### PR DESCRIPTION
Fixing the bug where multiple items can be retrieved from the Phantom Train

Tested by hitting A multiple times across Esper, Item, and Character reward seeds and confirming that only one can be received.