### PR TITLE
Added flag to exclude specific items by name

### DIFF
--- a/args/items.py
+++ b/args/items.py
@@ -55,6 +55,7 @@ def parse(parser):
                        help="All weapons enable swdtech and runic")
     items.add_argument("-saw", "--stronger-atma-weapon", action="store_true",
                        help="Atma Weapon moved to higher tier and divisor reduced from 64 to 32")
+    items.add_argument("-exi", "--exclude-items", type=str, help="Items to exclude from shops and chests.  Doesn't affect drops.  Separate with periods")
 
 
 def process(args):
@@ -177,6 +178,8 @@ def flags(args):
 
     if args.stronger_atma_weapon:
         flags += " -saw"
+    if args.exclude_items:
+        flags += f" -exi {args.exclude_items}"
 
     return flags
 

--- a/data/items.py
+++ b/data/items.py
@@ -357,6 +357,11 @@ class Items():
             exclude.append(name_id["Cursed Shld"])
         if self.args.permadeath:
             exclude.append(name_id["Fenix Down"])
+        if self.args.exclude_items:
+            try:
+                exclude.extend([name_id[item_name] for item_name in self.args.exclude_items.split(".")])
+            except KeyError as e:
+                raise KeyError(f"Item to exclude with -exi not found: {e}.  Check the spelling and capitalization")
 
         return exclude
 


### PR DESCRIPTION
Example use case:  flagset with auto-berserk but you want to make sure that Ribbons and Peace Rings don't show up in shops or chests: `-exi "Ribbon.Peace Ring"`