### PR TITLE
Generic Custom Starting Items Flag

### DIFF
--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -30,9 +30,9 @@ def process(args):
             self.id = _id
             self.count = count
     args.start_items_list = []
-    total_item_count = 0
     if args.start_items != None:
         values = args.start_items.split(".")
+        total_item_commands = 0
         if len(values) % 3 != 0:
             import sys
             args.parser.print_usage()
@@ -89,12 +89,12 @@ def process(args):
             if item_count > 0:
                 item = Item(item_id, item_count)
                 args.start_items_list.append(item)
-                total_item_count += item_count
-    if total_item_count > 100 :
-        import sys
-        args.parser.print_usage()
-        print(f"{sys.argv[0]}: error: start-items: '{total_item_count}' Items are trying to be added in total. Only up to 100 items are supported")
-        sys.exit(1)
+                total_item_commands += 1
+        if total_item_commands > 30 :
+            import sys
+            args.parser.print_usage()
+            print(f"{sys.argv[0]}: error: start-items: '{total_item_commands}' Item types are trying to be added in total. Only up to 30 are supported")
+            sys.exit(1)
 
 def flags(args):
     flags = ""

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -30,6 +30,7 @@ def process(args):
             self.id = _id
             self.count = count
     args.start_items_list = []
+    total_item_count = 0
     if args.start_items != None:
         values = args.start_items.split(".")
         if len(values) % 3 != 0:
@@ -88,6 +89,12 @@ def process(args):
             if item_count > 0:
                 item = Item(item_id, item_count)
                 args.start_items_list.append(item)
+                total_item_count += item_count
+    if total_item_count > 100 :
+        import sys
+        args.parser.print_usage()
+        print(f"{sys.argv[0]}: error: start-items: '{total_item_count}' Items are trying to be added in total. Only upto 100 items are supported")
+        sys.exit(1)
 
 def flags(args):
     flags = ""

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -79,13 +79,10 @@ def process(args):
                 args.parser.print_usage()
                 print(f"{sys.argv[0]}: error: start-items: '{max}' is an invalid count for an item. It must be between 1-99")
                 sys.exit(1)
-<<<<<<< Updated upstream
-=======
             if max < min:
                 import sys
                 args.parser.print_usage()
                 print(f"{sys.argv[0]}: error: start-items: max:'{max}' must be greater than the min:'{min}'")
->>>>>>> Stashed changes
 
             item_count = random.sample(range(min, max + 1), 1)[0]
             if item_count > 0:

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -93,7 +93,7 @@ def process(args):
     if total_item_count > 100 :
         import sys
         args.parser.print_usage()
-        print(f"{sys.argv[0]}: error: start-items: '{total_item_count}' Items are trying to be added in total. Only upto 100 items are supported")
+        print(f"{sys.argv[0]}: error: start-items: '{total_item_count}' Items are trying to be added in total. Only up to 100 items are supported")
         sys.exit(1)
 
 def flags(args):

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -1,3 +1,5 @@
+import random
+
 def name():
     return "Starting Gold/Items"
 
@@ -30,12 +32,12 @@ def process(args):
     args.start_items_list = []
     if args.start_items != None:
         values = args.start_items.split(".")
-        if len(values) % 2 == 1:
+        if len(values) % 3 != 0:
             import sys
             args.parser.print_usage()
-            print(f"{sys.argv[0]}: error: start-items: Invalid number of entries, they must come in pairs 'item_id.item_count'")
+            print(f"{sys.argv[0]}: error: start-items: Invalid number of entries, they must come in groups of 3 'item_id.min.max'")
             sys.exit(1)
-        for index in range(0, len(values), 2):
+        for index in range(0, len(values), 3):
             item_id = 0
             try:
                 item_id = int(values[index])
@@ -50,20 +52,35 @@ def process(args):
                 print(f"{sys.argv[0]}: error: start-items: '{item_id}' is an invalid value for an item id. It must be between 0-254")
                 sys.exit(1)
 
-            item_count = 0
+            min = 0
             try:
-                item_count = int(values[index + 1])
+                min = int(values[index + 1])
             except:
                 import sys
                 args.parser.print_usage()
                 print(f"{sys.argv[0]}: error: start-items: Failed to convert value into an int '{values[index+1]}'")
                 sys.exit(1)
-            if item_count <= 0 or item_count > 99:
+            if min < 0 or min > 99:
                 import sys
                 args.parser.print_usage()
-                print(f"{sys.argv[0]}: error: start-items: '{item_count}' is an invalid count for an item. It must be between 1-99")
+                print(f"{sys.argv[0]}: error: start-items: '{min}' is an invalid min for an item. It must be between 0-99")
                 sys.exit(1)
 
+            max = 0
+            try:
+                max = int(values[index + 2])
+            except:
+                import sys
+                args.parser.print_usage()
+                print(f"{sys.argv[0]}: error: start-items: Failed to convert value into an int '{values[index+2]}'")
+                sys.exit(1)
+            if max <= 0 or max > 99:
+                import sys
+                args.parser.print_usage()
+                print(f"{sys.argv[0]}: error: start-items: '{max}' is an invalid count for an item. It must be between 1-99")
+                sys.exit(1)
+
+            item_count = random.sample(range(min, max + 1), 1)[0]
             item = Item(item_id, item_count)
             args.start_items_list.append(item)
 

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -60,10 +60,10 @@ def process(args):
                 args.parser.print_usage()
                 print(f"{sys.argv[0]}: error: start-items: Failed to convert value into an int '{values[index+1]}'")
                 sys.exit(1)
-            if min < 0 or min > 99:
+            if min > 99:
                 import sys
                 args.parser.print_usage()
-                print(f"{sys.argv[0]}: error: start-items: '{min}' is an invalid min for an item. It must be between 0-99")
+                print(f"{sys.argv[0]}: error: start-items: '{min}' is an invalid min for an item. It must be less than 99")
                 sys.exit(1)
 
             max = 0
@@ -79,10 +79,18 @@ def process(args):
                 args.parser.print_usage()
                 print(f"{sys.argv[0]}: error: start-items: '{max}' is an invalid count for an item. It must be between 1-99")
                 sys.exit(1)
+<<<<<<< Updated upstream
+=======
+            if max < min:
+                import sys
+                args.parser.print_usage()
+                print(f"{sys.argv[0]}: error: start-items: max:'{max}' must be greater than the min:'{min}'")
+>>>>>>> Stashed changes
 
             item_count = random.sample(range(min, max + 1), 1)[0]
-            item = Item(item_id, item_count)
-            args.start_items_list.append(item)
+            if item_count > 0:
+                item = Item(item_id, item_count)
+                args.start_items_list.append(item)
 
 def flags(args):
     flags = ""

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -107,6 +107,8 @@ def options(args):
     for item in args.start_items_list:
         from constants.items import id_name
         item_name = id_name[item.id]
+        if not item_name.endswith("s"):
+            item_name = item_name + "s"
         opts += [
             (f"Start {item_name}", item.count, "start_items")
         ]

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -22,7 +22,7 @@ def parse(parser):
                                      help = "Start game with %(metavar)s different random tools"),
     starting_gold_items.add_argument("-sj", "--start-junk", default = 0, type = int, choices = range(25), metavar = "COUNT",
                                      help = "Start game with %(metavar)s unique low tier items. Includes weapons, armors, helmets, shields, and relics"),
-    starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start game with custom items.")
+    starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start game with items.")
 
 def process(args):
     class Item:
@@ -30,6 +30,17 @@ def process(args):
             self.id = _id
             self.count = count
     args.start_items_list = []
+
+    # convert old starting item flags to -si type values
+    if args.start_moogle_charms != 0:
+        args.start_items_list.append(Item(222, args.start_moogle_charms))
+    if args.start_sprint_shoes != 0:
+        args.start_items_list.append(Item(230, args.start_sprint_shoes))
+    if args.start_warp_stones != 0:
+        args.start_items_list.append(Item(253, args.start_warp_stones))
+    if args.start_fenix_downs != 0:
+        args.start_items_list.append(Item(240, args.start_fenix_downs))
+
     if args.start_items != None:
         values = args.start_items.split(".")
         total_item_commands = 0
@@ -121,10 +132,6 @@ def flags(args):
 def options(args):
     opts = [
         ("Start Gold", args.gold, "gold"),
-        ("Start Moogle Charms", args.start_moogle_charms, "start_moogle_charms"),
-        ("Start Sprint Shoes", args.start_sprint_shoes, "start_sprint_shoes"),
-        ("Start Warp Stones", args.start_warp_stones, "start_warp_stones"),
-        ("Start Fenix Downs", args.start_fenix_downs, "start_fenix_downs"),
         ("Start Tools", args.start_tools, "start_tools"),
     ]
     

--- a/event/start.py
+++ b/event/start.py
@@ -226,10 +226,9 @@ class Start(Event):
             ]
 
         for item in self.args.start_items_list:
-            for i in range(item.count):
-                src += [
-                    field.AddItem(item.id, sound_effect = False),
-                ]
+            src += [
+                field.AddItems(item.id, item.count, sound_effect = False),
+            ]
 
         if self.args.debug:
             src += [

--- a/event/start.py
+++ b/event/start.py
@@ -225,6 +225,12 @@ class Start(Event):
                 field.AddItem(id_name[junk_id], sound_effect = False)
             ]
 
+        for item in self.args.start_items_list:
+            for i in range(item.count):
+                src += [
+                    field.AddItem(item.id, sound_effect = False),
+                ]
+
         if self.args.debug:
             src += [
                 field.AddItem("Dried Meat", sound_effect = False),

--- a/event/start.py
+++ b/event/start.py
@@ -183,22 +183,6 @@ class Start(Event):
 
     def start_items_mod(self):
         src = []
-        for mc in range(self.args.start_moogle_charms):
-            src += [
-                field.AddItem("Moogle Charm", sound_effect = False),
-            ]
-        for mc in range(self.args.start_sprint_shoes):
-            src += [
-                field.AddItem("Sprint Shoes", sound_effect = False),
-            ]
-        for ws in range(self.args.start_warp_stones):
-            src += [
-                field.AddItem("Warp Stone", sound_effect = False),
-            ]
-        for fd in range(self.args.start_fenix_downs):
-            src += [
-                field.AddItem("Fenix Down", sound_effect = False),
-            ]
 
         tools = ["NoiseBlaster", "Bio Blaster", "Flash", "Chain Saw",
                  "Debilitator", "Drill", "Air Anchor", "AutoCrossbow"]

--- a/instruction/field/instructions.py
+++ b/instruction/field/instructions.py
@@ -129,6 +129,31 @@ def AddItem(item, sound_effect = True):
     else:
         return AddItem(item)
 
+class _AddItems(_Instruction):
+    def __init__(self, item, count):
+        if isinstance(item, str):
+            from data.item_names import name_id
+            self.item = name_id[item]
+            self.item_name = item
+        else:
+            from data.item_names import id_name
+            self.item = item
+            self.item_name = id_name[item]
+        if count == 1:
+            super().__init__(0x80, self.item)
+        else:
+            super().__init__(0xB0, count, 0x80, self.item, 0xB1)
+
+    def __str__(self):
+        return super().__str__(f"'{self.item_name}'")
+
+def AddItems(item, count, sound_effect = True):
+    AddItems = type("AddItems", (_AddItems,), {})
+    if sound_effect:
+        return AddItems(item, count), PlaySoundEffect(141)
+    else:
+        return AddItems(item, count)
+
 class AddGP(_Instruction):
     MAX = 2 ** 16 - 1 # 2 bytes max value
     def __init__(self, amount):


### PR DESCRIPTION
This adds a flag that supports creating any combination of starting items/quantities.  I have a corresponding branch for the Website here, https://github.com/JackQuincy/ultima/pull/1 .  I'll retarget that PR etc. if/when this one merges.

Details.
Adds a new flag `-si` or `--start-items` that has a follow up string that is a list of integers that are `.` separated. There needs to be a clean set of groups of 3 items and they are paired up 1st. 2nd and 3rd, 4th, 5th and 6th, etc.  the first number of the group needs to be a number between 0-254 which is the id of the item to be granted, the 2nd number is the min quantity of the item to grant, and the 3rd number is the max number of items to grant.

eg.  `-si 240.10.12.246.20.30.233.10.12.241.8.10.245.8.10.232.30.252.3.5.253.6.10.254.1.3` would grant the player 10-12 phoenix downs, 20-30 sleeping bags, 10-12 potions, 8-10 remedies, 8-10 revivifies, 20-30 tonics, 3-5 smoke bombs, 6-10 warp stones and 1-3 dried meat.