### PR TITLE
Remove Dried Meat from Figaro Castle WOR and Phantom Train shops and expand Starting Dried Meat flag range

### DIFF
--- a/args/shops.py
+++ b/args/shops.py
@@ -29,7 +29,7 @@ def parse(parser):
     shops_sell_fraction.add_argument("-ssf0", "--shop-sell-fraction0", action = "store_true",
                                      help = "Items sell for zero")
 
-    shops.add_argument("-sdm", "--shop-dried-meat", default = 1, type = int, choices = range(6), metavar = "COUNT",
+    shops.add_argument("-sdm", "--shop-dried-meat", default = 1, type = int, choices = range(11), metavar = "COUNT",
                         help = "%(metavar)s shops will contain dried meat")
     shops.add_argument("-npi", "--no-priceless-items", action = "store_true",
                        help = "Assign values to items which normally sell for 1 gold. Recommended with random inventory")

--- a/event/phantom_train.py
+++ b/event/phantom_train.py
@@ -54,12 +54,6 @@ class PhantomTrain(Event):
             field.ReturnIfEventBitClear(event_bit.character_recruited(self.character_gate())),
         )
 
-        sabin_path = self.characters.get_character_path(self.characters.SABIN)
-        veldt_gate = self.events["Veldt"].character_gate()
-        if veldt_gate in sabin_path and self.args.shop_dried_meat == 1:
-            # sabin requires veldt gate character and there is only one dried meat in shops
-            # make sure it is not in the phantom train
-            self.shops.no_dried_meat_phantom_train()
 
     def _load_world_map(self):
         src = [


### PR DESCRIPTION
Previously, code was in place to prevent Dried Meat from being placed in the Phantom Train item shop if only one shop was set to contain Dried Meat (to avoid secondary gating of Gau's Veldt check behind Sabin's Phantom Train check).

This code has been replaced by a more streamlined solution always prevents Dried Meat from appearing in the Phantom Train shop, and further adds the two shops in WOR Figaro Castle (gated behind Edgar) as excluded shops for Dried Meat placement.

The new code:
- Generates shops normally according to shop flags
- Removes Dried Meat from any shop on the exclude list (Phantom Train, Figaro WOR Left, and Figaro WOR Right) **without** replacement of a random shop item
- If # of shops with Dried Meat is greater than the Starting Dried Meat flag parameter, Dried Meat is removed at random (with no replacement) until reaching the targeted number
- If # of shops with Dried Meat is less than the flag, then Dried Meat is randomly added to shops (excluding the named shops above), replacing a random item available if the shop is already full

In addition to the above change, the Starting Dried Meat flag (`-sdm`) has had the input range expanded to 0-10 (was 0-5).