### PR TITLE
Generic starting items

### DIFF
--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -22,7 +22,7 @@ def parse(parser):
                                      help = "Start game with %(metavar)s different random tools"),
     starting_gold_items.add_argument("-sj", "--start-junk", default = 0, type = int, choices = range(25), metavar = "COUNT",
                                      help = "Start game with %(metavar)s unique low tier items. Includes weapons, armors, helmets, shields, and relics"),
-    starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start game with custom items.")
+    starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start game with items.")
 
 def process(args):
     class Item:
@@ -30,6 +30,17 @@ def process(args):
             self.id = _id
             self.count = count
     args.start_items_list = []
+
+    # convert old starting item flags to -si type values
+    if args.start_moogle_charms != 0:
+        args.start_items_list.append(Item(222, args.start_moogle_charms))
+    if args.start_sprint_shoes != 0:
+        args.start_items_list.append(Item(230, args.start_sprint_shoes))
+    if args.start_warp_stones != 0:
+        args.start_items_list.append(Item(253, args.start_warp_stones))
+    if args.start_fenix_downs != 0:
+        args.start_items_list.append(Item(240, args.start_fenix_downs))
+
     if args.start_items != None:
         values = args.start_items.split(".")
         total_item_commands = 0
@@ -121,10 +132,6 @@ def flags(args):
 def options(args):
     opts = [
         ("Start Gold", args.gold, "gold"),
-        ("Start Moogle Charms", args.start_moogle_charms, "start_moogle_charms"),
-        ("Start Sprint Shoes", args.start_sprint_shoes, "start_sprint_shoes"),
-        ("Start Warp Stones", args.start_warp_stones, "start_warp_stones"),
-        ("Start Fenix Downs", args.start_fenix_downs, "start_fenix_downs"),
         ("Start Tools", args.start_tools, "start_tools"),
     ]
     

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -22,7 +22,7 @@ def parse(parser):
                                      help = "Start game with %(metavar)s different random tools"),
     starting_gold_items.add_argument("-sj", "--start-junk", default = 0, type = int, choices = range(25), metavar = "COUNT",
                                      help = "Start game with %(metavar)s unique low tier items. Includes weapons, armors, helmets, shields, and relics"),
-    starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start game with items.")
+    starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start the game with items.")
 
 def process(args):
     from constants.items import name_id
@@ -105,10 +105,10 @@ def process(args):
             item = StartingItem(item_id, min, max)
             args.start_items_list.append(item)
             total_item_commands += 1
-        if total_item_commands > 30 :
+        if total_item_commands > 100 :
             import sys
             args.parser.print_usage()
-            print(f"{sys.argv[0]}: error: start-items: '{total_item_commands}' Item types are trying to be added in total. Only up to 30 are supported")
+            print(f"{sys.argv[0]}: error: start-items: '{total_item_commands}' Item types are trying to be added in total. Only up to 100 are supported")
             sys.exit(1)
 
 def flags(args):

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -100,6 +100,7 @@ def process(args):
                 import sys
                 args.parser.print_usage()
                 print(f"{sys.argv[0]}: error: start-items: max:'{max}' must be greater than or equal to the min:'{min}'")
+                sys.exit(1)
 
             item = StartingItem(item_id, min, max)
             args.start_items_list.append(item)
@@ -146,10 +147,13 @@ def options(args):
     for item in args.start_items_list:
         from constants.items import id_name
         item_name = id_name[item.id]
+        min = item.min
+        if min < 0:
+            min = 0
         if not item_name.endswith("s"):
             item_name = item_name + "s"
         opts += [
-            (f"Start {item_name}", f"{item.min}-{item.max}", "start_items")
+            (f"Start {item_name}", f"{min}-{item.max}", "start_items")
         ]
 
     return opts

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -105,10 +105,10 @@ def process(args):
             item = StartingItem(item_id, min, max)
             args.start_items_list.append(item)
             total_item_commands += 1
-        if total_item_commands > 100 :
+        if total_item_commands > 30 :
             import sys
             args.parser.print_usage()
-            print(f"{sys.argv[0]}: error: start-items: '{total_item_commands}' Item types are trying to be added in total. Only up to 100 are supported")
+            print(f"{sys.argv[0]}: error: start-items: '{total_item_commands}' Item types are trying to be added in total. Only up to 30 are supported")
             sys.exit(1)
 
 def flags(args):

--- a/args/starting_gold_items.py
+++ b/args/starting_gold_items.py
@@ -25,21 +25,26 @@ def parse(parser):
     starting_gold_items.add_argument("-si", "--start-items", default = None, type = str, help = "Start game with items.")
 
 def process(args):
-    class Item:
-        def __init__(self, _id, count):
-            self.id = _id
-            self.count = count
+    from constants.items import name_id
+    class StartingItem:
+        def __init__(self, _nid, min, max):
+            if isinstance(_nid, str):
+                   self.id = name_id[_nid]
+            else:
+                   self.id = _nid
+            self.min = min
+            self.max = max
     args.start_items_list = []
 
     # convert old starting item flags to -si type values
     if args.start_moogle_charms != 0:
-        args.start_items_list.append(Item(222, args.start_moogle_charms))
+        args.start_items_list.append(StartingItem(222, args.start_moogle_charms, args.start_moogle_charms))
     if args.start_sprint_shoes != 0:
-        args.start_items_list.append(Item(230, args.start_sprint_shoes))
+        args.start_items_list.append(StartingItem(230, args.start_sprint_shoes, args.start_sprint_shoes))
     if args.start_warp_stones != 0:
-        args.start_items_list.append(Item(253, args.start_warp_stones))
+        args.start_items_list.append(StartingItem(253, args.start_warp_stones, args.start_warp_stones))
     if args.start_fenix_downs != 0:
-        args.start_items_list.append(Item(240, args.start_fenix_downs))
+        args.start_items_list.append(StartingItem(240, args.start_fenix_downs, args.start_fenix_downs))
 
     if args.start_items != None:
         values = args.start_items.split(".")
@@ -94,13 +99,11 @@ def process(args):
             if max < min:
                 import sys
                 args.parser.print_usage()
-                print(f"{sys.argv[0]}: error: start-items: max:'{max}' must be greater than the min:'{min}'")
+                print(f"{sys.argv[0]}: error: start-items: max:'{max}' must be greater than or equal to the min:'{min}'")
 
-            item_count = random.sample(range(min, max + 1), 1)[0]
-            if item_count > 0:
-                item = Item(item_id, item_count)
-                args.start_items_list.append(item)
-                total_item_commands += 1
+            item = StartingItem(item_id, min, max)
+            args.start_items_list.append(item)
+            total_item_commands += 1
         if total_item_commands > 30 :
             import sys
             args.parser.print_usage()
@@ -146,7 +149,7 @@ def options(args):
         if not item_name.endswith("s"):
             item_name = item_name + "s"
         opts += [
-            (f"Start {item_name}", item.count, "start_items")
+            (f"Start {item_name}", f"{item.min}-{item.max}", "start_items")
         ]
 
     return opts

--- a/event/start.py
+++ b/event/start.py
@@ -225,6 +225,11 @@ class Start(Event):
                 field.AddItem(id_name[junk_id], sound_effect = False)
             ]
 
+        for item in self.args.start_items_list:
+            src += [
+                field.AddItems(item.id, item.count, sound_effect = False),
+            ]
+
         if self.args.debug:
             src += [
                 field.AddItem("Dried Meat", sound_effect = False),

--- a/event/start.py
+++ b/event/start.py
@@ -215,7 +215,7 @@ class Start(Event):
                 continue
 
             src += [
-                field.AddItems(item.id, item_count, sound_effect = False),
+                field.AddItems(item.id, item_count[0], sound_effect = False),
             ]
 
         if self.args.debug:

--- a/event/start.py
+++ b/event/start.py
@@ -183,22 +183,6 @@ class Start(Event):
 
     def start_items_mod(self):
         src = []
-        for mc in range(self.args.start_moogle_charms):
-            src += [
-                field.AddItem("Moogle Charm", sound_effect = False),
-            ]
-        for mc in range(self.args.start_sprint_shoes):
-            src += [
-                field.AddItem("Sprint Shoes", sound_effect = False),
-            ]
-        for ws in range(self.args.start_warp_stones):
-            src += [
-                field.AddItem("Warp Stone", sound_effect = False),
-            ]
-        for fd in range(self.args.start_fenix_downs):
-            src += [
-                field.AddItem("Fenix Down", sound_effect = False),
-            ]
 
         tools = ["NoiseBlaster", "Bio Blaster", "Flash", "Chain Saw",
                  "Debilitator", "Drill", "Air Anchor", "AutoCrossbow"]

--- a/event/start.py
+++ b/event/start.py
@@ -210,8 +210,9 @@ class Start(Event):
             ]
 
         for item in self.args.start_items_list:
+            item_count = random.sample(range(item.min, item.max+1), 1)
             src += [
-                field.AddItems(item.id, item.count, sound_effect = False),
+                field.AddItems(item.id, item_count, sound_effect = False),
             ]
 
         if self.args.debug:

--- a/event/start.py
+++ b/event/start.py
@@ -211,6 +211,8 @@ class Start(Event):
 
         for item in self.args.start_items_list:
             item_count = random.sample(range(item.min, item.max+1), 1)
+            if item_count[0] < 0:
+                item_count[0] = 0
             src += [
                 field.AddItems(item.id, item_count, sound_effect = False),
             ]

--- a/event/start.py
+++ b/event/start.py
@@ -211,8 +211,9 @@ class Start(Event):
 
         for item in self.args.start_items_list:
             item_count = random.sample(range(item.min, item.max+1), 1)
-            if item_count[0] < 0:
-                item_count[0] = 0
+            if item_count[0] <= 0:
+                continue
+
             src += [
                 field.AddItems(item.id, item_count, sound_effect = False),
             ]

--- a/instruction/field/instructions.py
+++ b/instruction/field/instructions.py
@@ -129,6 +129,31 @@ def AddItem(item, sound_effect = True):
     else:
         return AddItem(item)
 
+class _AddItems(_Instruction):
+    def __init__(self, item, count):
+        if isinstance(item, str):
+            from data.item_names import name_id
+            self.item = name_id[item]
+            self.item_name = item
+        else:
+            from data.item_names import id_name
+            self.item = item
+            self.item_name = id_name[item]
+        if count == 1:
+            super().__init__(0x80, self.item)
+        else:
+            super().__init__(0xB0, count, 0x80, self.item, 0xB1)
+
+    def __str__(self):
+        return super().__str__(f"'{self.item_name}'")
+
+def AddItems(item, count, sound_effect = True):
+    AddItems = type("AddItems", (_AddItems,), {})
+    if sound_effect:
+        return AddItems(item, count), PlaySoundEffect(141)
+    else:
+        return AddItems(item, count)
+
 class AddGP(_Instruction):
     MAX = 2 ** 16 - 1 # 2 bytes max value
     def __init__(self, amount):


### PR DESCRIPTION
https://github.com/asilverthorn/WorldsCollide/pull/24
Adding a flag -si Which allows starting with a generic set of items.

the value is a . separated list of numbers.
The list is broken into groups of 3
The first number in the group of 3 is the item id, 2nd the minimum value, and 3rd is the max value
There is a cap of having 30 different types of items to be added at the start of the seed
Negative values are allowed for the minimum which effectively increase the chance of starting with 0. So a range of -2 to 1 would have a 75% chance of having 0 of the item and 25% chance of having 1.
I updated the events adding starting items so that it can use loops to take less space when adding large numbers of items. When only adding 1 item the old method is still used.

I'm getting ready here to deprecate the older flags for adding specific items since this flag has the capability of doing that already.