### PR TITLE
Whos there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ $py.class
 *-objective.json
 *-flag.json
 wip/
+/diffs
+/tests
+ff3.smc

--- a/agents.md
+++ b/agents.md
@@ -77,9 +77,9 @@ MemoryError: Not enough room in space "custom event toggle": Next (0xc0f124) > E
 ```text
 AttributeError: module 'args' has no attribute 'my_new_flag'
 ```
-**Cause**: The subsystem list inside [arguments.py](file:///c:/Projects/wrjones104_WorldsCollide/args/arguments.py) does not contain your new module, or a circular dependency was introduced.
+**Cause**: The subsystem list inside [arguments.py](args/arguments.py) does not contain your new module, or a circular dependency was introduced.
 **Resolution**:
-1. Verify that your custom CLI option module is registered in `self.groups` inside the constructor of `Arguments` in [arguments.py](file:///c:/Projects/wrjones104_WorldsCollide/args/arguments.py#L4-L13).
+1. Verify that your custom CLI option module is registered in `self.groups` inside the constructor of `Arguments` in [arguments.py](args/arguments.py#L4-L13).
 2. Look at import structures. Ensure you did not import game subsystems globally at the top of your custom script file. Move imports inside functions (e.g. inside `mod()`) to resolve circular bindings.
 
 ### 3.3 Event Bit Validation Assertion
@@ -89,7 +89,7 @@ AssertionError: Number of char/esper only checks changed - Check usages of CHARA
 ```
 **Cause**: You modified the number of rewards in an event, causing the randomizer's gating logic to detect that the total available rewards no longer match the hardcoded pool sizes.
 **Resolution**:
-- If you deliberately added/removed a character/esper check to a quest event (e.g. `phoenix_cave.py`), you must update the global expected total `CHARACTER_ESPER_ONLY_REWARDS` constant in [constants/objectives/results.py](file:///c:/Projects/wrjones104_WorldsCollide/constants/objectives/results.py) (or related metadata files) so that the count validator passes.
+- If you deliberately added/removed a character/esper check to a quest event (e.g. `phoenix_cave.py`), you must update the global expected total `CHARACTER_ESPER_ONLY_REWARDS` constant in [constants/objectives/results.py](constants/objectives/results.py) (or related metadata files) so that the count validator passes.
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -114,3 +114,51 @@ graph TD
 4. **Compile & Generate**: Execute `python3 wc.py -i ff3.smc` to verify that standard seed compilation compiles cleanly.
 5. **Verify Outputs**: Use `valid_rom_file` verification logic to ensure ROM consistency where applicable.
 6. **Update Instruction Files**: Update both `llms.md` and `agents.md` immediately if any changes affect the structure or expectations documented inside these manuals.
+
+---
+
+## 5. Python 3.14 Set Sampling Guardrails
+
+**Error Signature**:
+```text
+TypeError: Population must be a sequence. For dicts or sets, use sorted(d).
+```
+**Cause**: Passing a `set` directly to `random.sample()` was deprecated in Python 3.9 and results in a fatal `TypeError` in newer Python versions (such as Python 3.11 through Python 3.14).
+**Resolution**:
+- Convert the set to a tuple before using random selection:
+  ```diff
+  - rand_item = random.sample(self.available_items, 1)[0]
+  + rand_item = random.sample(tuple(self.available_items), 1)[0]
+  ```
+- Converting the set to a tuple satisfies Python's sequence checks while maintaining 100% identical random state generation and choice behavior as the vanilla randomizer, preserving full seed compatibility.
+
+---
+
+## 6. Gating deadlocks (AssertionError) in choose_reward
+
+**Error Signature**:
+```text
+  File "event_reward.py", line 51, in choose_reward
+    assert(item_possible)
+AssertionError
+```
+**Cause**: The method `single_possible_type(self)` in `event/event_reward.py` returned `True` for compound flag values like `RewardType.CHARACTER | RewardType.ESPER` because `in RewardType` evaluated to `True` for valid flag combinations in Python's enum implementation. This caused these slots to be processed prematurely during `choose_single_possible_type_rewards` when no characters or espers were left, triggering gating deadlocks.
+**Resolution**:
+- Explicitly check against the exact single-member flags:
+  ```python
+  def single_possible_type(self):
+      return self.possible_types in (RewardType.CHARACTER, RewardType.ESPER, RewardType.ITEM)
+
+---
+
+## 7. Assembly Hooks and CPU Register Preservation
+
+**Error Signature**: Monster sprites appear as garbled noise blocks, or regular enemies have incorrect sprites.
+**Cause**: Modifying registers (such as `X` or `Y`) or using incorrect data bank instruction opcodes inside custom assembly subroutines. Specifically:
+1. Destructively overwriting `X` inside a hook when the caller context relies on `X` containing the original graphics index.
+2. Using 16-bit absolute address instructions like `LDA absolute,X` (`0xBD`) to access 24-bit dynamic ROM banks (`F0`), which reads from the incorrect data bank and treats the third address byte as the opcode of the next instruction, shifting the entire instruction stream.
+3. Looking up active monster IDs in the wrong table (like general actor list WRAM `$2001,X` where slot indices do not map directly to monster offsets), leading to missing or un-rendered sprite overlays in multi-boss battles.
+**Resolution**:
+- Always preserve and restore modified registers using `PHX`/`PLX` or `PHY`/`PLY` at the boundaries of your subroutine.
+- Use 24-bit long addressing opcodes (`0xAF` for `LDA long`, `0xBF` for `LDA long,X`) when referencing addresses dynamically allocated to Bank `F0`.
+- Always load active monster IDs directly from the active monster ID table WRAM `$812F,Y` (indexed by slot index * 2) after clearing the 16-bit Accumulator (using `TDC` `0x7B`) at the very beginning of the subroutine to avoid index register pollution from caller active CPU registers.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,116 @@
+# Operational Playbook for Autonomous AI Agents
+
+This document is written for autonomous AI coding agents (such as Antigravity, SWE-agent, etc.) that have system shell access, terminal execution tools, and the capability to make file edits. It details exact execution procedures, testing environments, diagnostic troubleshooting, and code modification guardrails.
+
+> [!IMPORTANT]
+> **SELF-UPDATE MANDATE**: If any changes you make to the codebase during your work affect existing patterns, add new modules, change core APIs, or introduce new paradigms, you **MUST** update this file (`agents.md`) and `llms.md` as part of your changes to keep future AI agents correctly instructed.
+
+---
+
+## 1. Prerequisites & Execution Environment
+
+### 1.1 Python Dependencies
+The randomizer runs entirely on Python 3 with the standard library. No external pip installations are required.
+
+### 1.2 Target ROM File
+To verify ROM modifications and successfully run a seed generation test, a valid Super Nintendo FF6 ROM file is required:
+- **Filename**: ff3.smc (located in the workspace root).
+- **Format**: Unheadered, 3,145,728 bytes (3MB).
+- **Verify ROM Validity**: You can check the ROM's validity by running:
+  ```powershell
+  python3 -c "import valid_rom_file; print(valid_rom_file.valid_rom_file('ff3.smc'))"
+  ```
+  It should output `True`.
+
+### 1.3 Test Data Isolation
+> [!IMPORTANT]
+> **TEST DATA DIRECTORY RULE**: All test output data (including modified test ROMs, debug log text files, or API metadata manifests generated during your test runs) **MUST** be isolated and placed inside a `tests` directory in the workspace root (e.g., `tests/test_output.smc`, `tests/test_output.txt`).
+> - Do not write test output files directly to the root directory.
+> - Ensure the `tests` directory is created before running commands (e.g. `mkdir -Force tests`).
+
+---
+
+## 2. Playbook Commands
+
+### 2.1 Basic Verification
+To test if the options interface parses arguments successfully without crashes:
+```powershell
+python3 wc.py -h
+```
+
+### 2.2 Seed Generation Verification
+To run a complete randomizer build, executing all event scripting, memory parsing, and ROM compilations:
+```powershell
+# Ensure the tests folder exists
+mkdir -Force tests
+
+# Run seed build outputting directly to the isolated tests folder
+python3 wc.py -i ff3.smc -o tests/test_output.smc
+```
+This generates the seed ROM and its log inside the `tests` directory.
+
+### 2.3 Debug Seeding with Logs
+To print full section reports (event rewards, character scaling, and shops mapping) to standard stdout:
+```powershell
+python3 wc.py -i ff3.smc -o tests/test_output.smc -debug -slog
+```
+
+---
+
+## 3. Diagnostic & Troubleshooting Guide
+
+During development, agents commonly trigger three specific errors. Here is how to diagnose and resolve them:
+
+### 3.1 Memory Overflow / Bank Exhaustion
+**Error Signature**:
+```text
+MemoryError: Not enough room in space "custom event toggle": Next (0xc0f124) > End (0xc0f100). Diff: 36
+```
+**Cause**: You have written more bytes of assembly instructions or static data than the target `Reserve` range fits, or have exceeded the size of a dynamically requested `Allocate` block in that bank.
+**Resolution**:
+1. Check the size parameters in your dynamic allocation: `Allocate(Bank.C0, size, "description")`. Increase `size` to support your assembly array length.
+2. If using a `Reserve` block, you are locked to vanilla game boundaries. You must rewrite your routine to be more byte-efficient (e.g., using shared subroutines with `JSR`/`JSL` or tighter register usage).
+3. Alternatively, place the bulk of your custom assembly payload inside a dynamic `Allocate` space in Bank `C0`, `C2`, or `F0`, and use the `Reserve` block only to write a `JMP` or `JSR` redirecting to your dynamically allocated address.
+
+### 3.2 Dynamic Import / Startup Crash
+**Error Signature**:
+```text
+AttributeError: module 'args' has no attribute 'my_new_flag'
+```
+**Cause**: The subsystem list inside [arguments.py](file:///c:/Projects/wrjones104_WorldsCollide/args/arguments.py) does not contain your new module, or a circular dependency was introduced.
+**Resolution**:
+1. Verify that your custom CLI option module is registered in `self.groups` inside the constructor of `Arguments` in [arguments.py](file:///c:/Projects/wrjones104_WorldsCollide/args/arguments.py#L4-L13).
+2. Look at import structures. Ensure you did not import game subsystems globally at the top of your custom script file. Move imports inside functions (e.g. inside `mod()`) to resolve circular bindings.
+
+### 3.3 Event Bit Validation Assertion
+**Error Signature**:
+```text
+AssertionError: Number of char/esper only checks changed - Check usages of CHARACTER_ESPER_ONLY_REWARDS...
+```
+**Cause**: You modified the number of rewards in an event, causing the randomizer's gating logic to detect that the total available rewards no longer match the hardcoded pool sizes.
+**Resolution**:
+- If you deliberately added/removed a character/esper check to a quest event (e.g. `phoenix_cave.py`), you must update the global expected total `CHARACTER_ESPER_ONLY_REWARDS` constant in [constants/objectives/results.py](file:///c:/Projects/wrjones104_WorldsCollide/constants/objectives/results.py) (or related metadata files) so that the count validator passes.
+
+---
+
+## 4. Step-by-Step Code Modification Protocol
+
+When tasked with implementing a new feature or fixing a bug, execute this cycle:
+
+```mermaid
+graph TD
+    A[1. Identify Target Component] --> B[2. Check Memory Allocations & Offsets]
+    B --> C[3. Implement Code Changes]
+    C --> D[4. Run CLI and Seed Build Tests]
+    D -->|Failure| E[5. Resolve Memory or Import Errors]
+    E --> C
+    D -->|Success| F[6. Run valid_rom_file Verification]
+    F --> G[7. Update llms.md and agents.md]
+```
+
+1. **Locate Target Files**: Pinpoint if you need to modify options (`args/`), data modeling (`data/`), events (`event/`), or CPU logic (`bug_fixes/`, `battle/`).
+2. **Review Offsets**: If doing assembly modifications, examine target ROM offsets to confirm no existing dynamic spaces overlap.
+3. **Write Pythonic Logic**: Use standard code paradigms. Implement localized dynamic imports to keep module initialization clean.
+4. **Compile & Generate**: Execute `python3 wc.py -i ff3.smc` to verify that standard seed compilation compiles cleanly.
+5. **Verify Outputs**: Use `valid_rom_file` verification logic to ensure ROM consistency where applicable.
+6. **Update Instruction Files**: Update both `llms.md` and `agents.md` immediately if any changes affect the structure or expectations documented inside these manuals.

--- a/args/bosses.py
+++ b/args/bosses.py
@@ -35,6 +35,8 @@ def parse(parser):
                         help = "Undead status removed from bosses")
     bosses.add_argument("-bmkl", "--boss-marshal-keep-lobos", action = "store_true",
                         help = "Don't replace the Marshal's Lobos with randomized enemies")
+    bosses.add_argument("-oops", default = None, type = str,
+                        help = "Oops, all <boss>! Replace all bosses with the specified boss enemy ID or name.")
 
 def process(args):
     if args.mix_bosses_dragons:
@@ -46,6 +48,37 @@ def process(args):
         args.dragon_boss_location = BossLocations.SHUFFLE
     if vanilla_locations and args.statue_boss_location == BossLocations.MIX:
         args.statue_boss_location = BossLocations.SHUFFLE
+
+    if args.oops is not None:
+        import data.bosses as bosses
+        excluded_final_battle_ids = set(bosses.final_battle_enemy_name.keys())
+        excluded_final_battle_ids.remove(298) # Keep Kefka (Final) as valid!
+
+        try:
+            # Try to parse as integer ID first
+            oops_id = int(args.oops)
+            if not (0 <= oops_id <= 383) or oops_id in excluded_final_battle_ids:
+                raise ValueError()
+            args.oops = oops_id
+        except ValueError:
+            # If not a valid integer ID, try to parse as normalized name
+            def normalize(name):
+                return "".join(c.lower() for c in name if c.isalnum())
+
+            name_to_id = {}
+            for enemy_dict in [bosses.normal_enemy_name, bosses.dragon_enemy_name, bosses.statue_enemy_name, bosses.final_battle_enemy_name]:
+                for eid, name in enemy_dict.items():
+                    if eid not in excluded_final_battle_ids:
+                        name_to_id[normalize(name)] = eid
+
+            normalized_input = normalize(args.oops)
+            if normalized_input in name_to_id:
+                args.oops = name_to_id[normalized_input]
+            else:
+                raise ValueError(
+                    f"Invalid boss ID or name: '{args.oops}'. "
+                    f"Please check the enemy maps in data/bosses.py for correct names and IDs."
+                )
 
 def flags(args):
     flags = ""
@@ -73,6 +106,8 @@ def flags(args):
         flags += " -bnu"
     if args.boss_marshal_keep_lobos:
         flags += " -bmkl"
+    if args.oops is not None:
+        flags += f" -oops {args.oops}"
 
     return flags
 
@@ -100,6 +135,7 @@ def options(args):
         ("Boss Experience", args.boss_experience, "boss_experience"),
         ("No Undead", args.boss_no_undead, "boss_no_undead"),
         ("Marshal Keep Lobos", args.boss_marshal_keep_lobos, "boss_marshal_keep_lobos"),
+        ("Oops All Boss ID", args.oops, "oops"),
     ]
 
 def menu(args):

--- a/args/graphics.py
+++ b/args/graphics.py
@@ -22,6 +22,9 @@ def parse(parser):
     graphics.add_argument("-ahtc", "--alternate-healing-text-color", action = "store_true",
                               help = "Makes healing text blue, to be able to distinguish from damage.")
 
+    graphics.add_argument("-who", "--who-there", action = "store_true",
+                              help = "Who's There? Bosses look like Imps and have the name '??????'")
+
 def process(args):
     import graphics.palettes.palettes as palettes
     import graphics.portraits.portraits as portraits
@@ -118,6 +121,8 @@ def flags(args):
         flags += " -wmhc"
     if args.alternate_healing_text_color:
         flags += " -ahtc"
+    if args.who_there:
+        flags += " -who"
 
     return flags
 
@@ -187,10 +192,15 @@ def _other_options_log(args):
     if args.alternate_healing_text_color:
         healing_text = "Blue"
 
+    who_there = "Original"
+    if args.who_there:
+        who_there = "Imps"
+
     entries = [
         ("Remove Flashes", remove_flashes, "remove_flashes"),
         ("World Minimap", world_minimap, "world_minimap"),
         ("Healing Text", healing_text, "healing_text"),
+        ("Who's There?", who_there, "who_there"),
     ]
 
     for entry in entries:

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -442,151 +442,93 @@ class Enemies():
         self.who_there_assembly()
 
     def who_there_assembly(self):
-        from memory.space import Allocate, Reserve, Bank
+        from memory.space import Bank, Write
         import instruction.asm as asm
 
         # 1. Allocate a 1-byte flag in ROM representing if the flag is active (it will be 1)
-        who_there_flag_space = Allocate(Bank.F0, 1, "who's there flag")
-        who_there_flag_space.write([1])
+        who_there_flag_space = Write(Bank.F0, [1], "who's there flag")
+        flag_addr = who_there_flag_space.start_address_snes
 
         # 2. Construct the 384-byte boss table
         boss_table_bytes = [0] * 384
         for enemy_id in bosses.enemy_name:
             if 0 <= enemy_id < 384:
                 boss_table_bytes[enemy_id] = 1
-        
-        # Include SrBehemoth (Undead) Phase 2
-        boss_table_bytes[282] = 1
-        
-        # Exclude Final Battle Tiers
-        for excluded_id in range(343, 352):
+        boss_table_bytes[282] = 1 # Include SrBehemoth (Undead) Phase 2
+        for excluded_id in range(343, 352): # Exclude Final Battle Tiers
             boss_table_bytes[excluded_id] = 0
         
-        boss_table_space = Allocate(Bank.F0, 384, "who's there boss table")
-        boss_table_space.write(boss_table_bytes)
-
-        # 3. Create the custom check_imp_graphics subroutine in Bank F0
-        # Write custom assembly code in C0 to check the flag and table
-        subroutine_space = Allocate(Bank.C0, 120, "who's there check imp graphics")
-        sub_addr = subroutine_space.start_address_snes
-
-        subroutine_bytes = []
-
-        # PHX (0xDA)
-        subroutine_bytes.append(0xda)
-        # TDC (0x7B) - Clear 16-bit Accumulator
-        subroutine_bytes.append(0x7b)
-
-        # LDA $81A7 (0xAD, 0xA7, 0x81)
-        subroutine_bytes.extend([0xad, 0xa7, 0x81])
-        # TAY (0xA8)
-        subroutine_bytes.append(0xa8)
-        # LDA $62C2,Y (0xB9, 0xC2, 0x62)
-        subroutine_bytes.extend([0xb9, 0xc2, 0x62])
-        # BNE .is_imp (offset 0x30)
-        subroutine_bytes.extend([0xd0, 0x30])
-
-        # LDA $81A7 (0xAD, 0xA7, 0x81)
-        subroutine_bytes.extend([0xad, 0xa7, 0x81])
-        # ASL A (0x0A)
-        subroutine_bytes.append(0x0a)
-        # TAX (0xAA)
-        subroutine_bytes.append(0xaa)
-
-        # REP #$20 (0xC2, 0x20)
-        subroutine_bytes.extend([0xc2, 0x20])
-        # LDA $2001,X (0xBD, 0x01, 0x20)
-        subroutine_bytes.extend([0xbd, 0x01, 0x20])
-        # CMP #384 (0xC9, 0x80, 0x01)
-        subroutine_bytes.extend([0xc9, 0x80, 0x01])
-        # BCS .not_imp_16 (offset 0x17)
-        subroutine_bytes.extend([0xb0, 0x17])
-        # TAX (0xAA)
-        subroutine_bytes.append(0xaa)
-        # SEP #$20 (0xE2, 0x20)
-        subroutine_bytes.extend([0xe2, 0x20])
-
-        # LDA long who_there_flag (0xAF)
-        flag_addr = who_there_flag_space.start_address_snes
-        subroutine_bytes.extend([0xaf, flag_addr & 0xff, (flag_addr >> 8) & 0xff, (flag_addr >> 16) & 0xff])
-        # BEQ .not_imp (offset 0x06)
-        subroutine_bytes.extend([0xf0, 0x06])
-
-        # LDA long boss_table,X (0xBF)
+        boss_table_space = Write(Bank.F0, boss_table_bytes, "who's there boss table")
         table_addr = boss_table_space.start_address_snes
-        subroutine_bytes.extend([0xbf, table_addr & 0xff, (table_addr >> 8) & 0xff, (table_addr >> 16) & 0xff])
-        # BNE .is_imp (offset 0x12)
-        subroutine_bytes.extend([0xd0, 0x12])
 
-        # .not_imp:
-        # PLX (0xFA)
-        subroutine_bytes.append(0xfa)
-        # LDA $81A7 (0xAD, 0xA7, 0x81)
-        subroutine_bytes.extend([0xad, 0xa7, 0x81])
-        # TAY (0xA8)
-        subroutine_bytes.append(0xa8)
-        # LDA #$00 (0xA9, 0x00)
-        subroutine_bytes.extend([0xa9, 0x00])
-        # RTL (0x6B)
-        subroutine_bytes.append(0x6b)
+        # 3. Create the custom check_imp_graphics subroutine in Bank C0
+        src = [
+            asm.PHX(),
+            asm.TDC(),
+            asm.LDA(0x81A7, asm.ABS),
+            asm.TAY(),
+            asm.LDA(0x62C2, asm.ABS_Y),
+            asm.BNE("IS_IMP"),
 
-        # .not_imp_16:
-        # SEP #$20 (0xE2, 0x20)
-        subroutine_bytes.extend([0xe2, 0x20])
-        # PLX (0xFA)
-        subroutine_bytes.append(0xfa)
-        # LDA $81A7 (0xAD, 0xA7, 0x81)
-        subroutine_bytes.extend([0xad, 0xa7, 0x81])
-        # TAY (0xA8)
-        subroutine_bytes.append(0xa8)
-        # LDA #$00 (0xA9, 0x00)
-        subroutine_bytes.extend([0xa9, 0x00])
-        # RTL (0x6B)
-        subroutine_bytes.append(0x6b)
+            asm.LDA(0x81A7, asm.ABS),
+            asm.ASL(),
+            asm.TAX(),
 
-        # .is_imp:
-        # LDA $81A7 (0xAD, 0xA7, 0x81)
-        subroutine_bytes.extend([0xad, 0xa7, 0x81])
-        # ASL A (0x0A)
-        subroutine_bytes.append(0x0a)
-        # TAX (0xAA)
-        subroutine_bytes.append(0xaa)
-        # REP #$20 (0xC2, 0x20)
-        subroutine_bytes.extend([0xc2, 0x20])
-        # LDA #$0000 (0xA9, 0x00, 0x00)
-        subroutine_bytes.extend([0xa9, 0x00, 0x00])
-        # STA $812F,X (0x9D, 0x2F, 0x81)
-        subroutine_bytes.extend([0x9d, 0x2f, 0x81])
-        # SEP #$20 (0xE2, 0x20)
-        subroutine_bytes.extend([0xe2, 0x20])
+            asm.A16(),
+            asm.LDA(0x812F, asm.ABS_X), # Use 812F as per documentation in agents.md
+            asm.CMP(384, asm.IMM16),
+            asm.BCS("NOT_IMP_16"),
+            asm.TAX(),
+            asm.A8(),
 
-        # PLX (0xFA)
-        subroutine_bytes.append(0xfa)
-        # LDA $81A7 (0xAD, 0xA7, 0x81)
-        subroutine_bytes.extend([0xad, 0xa7, 0x81])
-        # TAY (0xA8)
-        subroutine_bytes.append(0xa8)
-        # LDA #$01 (0xA9, 0x01)
-        subroutine_bytes.extend([0xa9, 0x01])
-        # RTL (0x6B)
-        subroutine_bytes.append(0x6b)
+            asm.LDA(flag_addr, asm.LNG),
+            asm.BEQ("NOT_IMP"),
 
-        subroutine_space.write(subroutine_bytes)
+            asm.LDA(table_addr, asm.LNG_X),
+            asm.BNE("IS_IMP"),
+
+            "NOT_IMP",
+            asm.PLX(),
+            asm.LDA(0x81A7, asm.ABS),
+            asm.TAY(),
+            asm.LDA(0x00, asm.IMM8),
+            asm.RTL(),
+
+            "NOT_IMP_16",
+            asm.A8(),
+            asm.PLX(),
+            asm.LDA(0x81A7, asm.ABS),
+            asm.TAY(),
+            asm.LDA(0x00, asm.IMM8),
+            asm.RTL(),
+
+            "IS_IMP",
+            asm.LDA(0x81A7, asm.ABS),
+            asm.ASL(),
+            asm.TAX(),
+            asm.A16(),
+            asm.LDA(0x0000, asm.IMM16),
+            asm.STA(0x812F, asm.ABS_X),
+            asm.A8(),
+
+            asm.PLX(),
+            asm.LDA(0x81A7, asm.ABS),
+            asm.TAY(),
+            asm.LDA(0x01, asm.IMM8),
+            asm.RTL(),
+        ]
+        subroutine_space = Write(Bank.C0, src, "who's there check imp graphics")
+        sub_addr = subroutine_space.start_address_snes
 
         # 4. Patch the original graphics loader at ROM offset 0x01207B (Bank C1)
-        # We replace 9 bytes from 0x01207B to 0x012083 with:
-        # JSL check_imp_graphics (4 bytes)
-        # BEQ $09 (2 bytes)
-        # NOP (3 bytes)
-        patch_space = Reserve(0x01207b, 0x012083, "who's there imp graphics loader hook", asm.NOP())
-        
-        sub_addr = subroutine_space.start_address_snes
-        patch_bytes = [
-            0x22, sub_addr & 0xff, (sub_addr >> 8) & 0xff, (sub_addr >> 16) & 0xff, # JSL check_imp_graphics
-            0xf0, 0x09,                                                            # BEQ $09 (to 0x01208A)
-            0xea, 0xea, 0xea                                                       # NOPs
+        patch_src = [
+            asm.JSL(sub_addr),
+            asm.BEQ(0x09), # Branch to 0x01208A
+            asm.NOP(),
+            asm.NOP(),
+            asm.NOP(),
         ]
-        patch_space.write(patch_bytes)
+        Write(0x01207b, patch_src, "who's there imp graphics loader hook")
 
     def get_event_boss(self, original_boss_name):
         return self.packs.get_event_boss_replacement(original_boss_name)

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -398,12 +398,161 @@ class Enemies():
         self.zones.mod()
         self.scripts.mod()
 
+        if self.args.who_there:
+            self.who_there_mod()
+
         if self.args.scan_all:
             self.scan_all()
 
         if self.args.debug:
             for enemy in self.enemies:
                 enemy.debug_mod()
+
+    def who_there_mod(self):
+        for enemy in self.enemies:
+            if enemy.id in bosses.enemy_name:
+                enemy.name = "??????"
+        self.who_there_assembly()
+
+    def who_there_assembly(self):
+        from memory.space import Allocate, Reserve, Bank
+        import instruction.asm as asm
+
+        # 1. Allocate a 1-byte flag in ROM representing if the flag is active (it will be 1)
+        who_there_flag_space = Allocate(Bank.F0, 1, "who's there flag")
+        who_there_flag_space.write([1])
+
+        # 2. Construct the 384-byte boss table
+        boss_table_bytes = [0] * 384
+        for enemy_id in bosses.enemy_name:
+            if 0 <= enemy_id < 384:
+                boss_table_bytes[enemy_id] = 1
+        
+        boss_table_space = Allocate(Bank.F0, 384, "who's there boss table")
+        boss_table_space.write(boss_table_bytes)
+
+        # 3. Create the custom check_imp_graphics subroutine in Bank F0
+        # Write custom assembly code in C0 to check the flag and table
+        subroutine_space = Allocate(Bank.C0, 120, "who's there check imp graphics")
+        sub_addr = subroutine_space.start_address_snes
+
+        subroutine_bytes = []
+
+        # PHX (0xDA)
+        subroutine_bytes.append(0xda)
+        # TDC (0x7B) - Clear 16-bit Accumulator
+        subroutine_bytes.append(0x7b)
+
+        # LDA $81A7 (0xAD, 0xA7, 0x81)
+        subroutine_bytes.extend([0xad, 0xa7, 0x81])
+        # TAY (0xA8)
+        subroutine_bytes.append(0xa8)
+        # LDA $62C2,Y (0xB9, 0xC2, 0x62)
+        subroutine_bytes.extend([0xb9, 0xc2, 0x62])
+        # BNE .is_imp (offset 0x30)
+        subroutine_bytes.extend([0xd0, 0x30])
+
+        # LDA $81A7 (0xAD, 0xA7, 0x81)
+        subroutine_bytes.extend([0xad, 0xa7, 0x81])
+        # ASL A (0x0A)
+        subroutine_bytes.append(0x0a)
+        # TAX (0xAA)
+        subroutine_bytes.append(0xaa)
+
+        # REP #$20 (0xC2, 0x20)
+        subroutine_bytes.extend([0xc2, 0x20])
+        # LDA $2001,X (0xBD, 0x01, 0x20)
+        subroutine_bytes.extend([0xbd, 0x01, 0x20])
+        # CMP #384 (0xC9, 0x80, 0x01)
+        subroutine_bytes.extend([0xc9, 0x80, 0x01])
+        # BCS .not_imp_16 (offset 0x17)
+        subroutine_bytes.extend([0xb0, 0x17])
+        # TAX (0xAA)
+        subroutine_bytes.append(0xaa)
+        # SEP #$20 (0xE2, 0x20)
+        subroutine_bytes.extend([0xe2, 0x20])
+
+        # LDA long who_there_flag (0xAF)
+        flag_addr = who_there_flag_space.start_address_snes
+        subroutine_bytes.extend([0xaf, flag_addr & 0xff, (flag_addr >> 8) & 0xff, (flag_addr >> 16) & 0xff])
+        # BEQ .not_imp (offset 0x06)
+        subroutine_bytes.extend([0xf0, 0x06])
+
+        # LDA long boss_table,X (0xBF)
+        table_addr = boss_table_space.start_address_snes
+        subroutine_bytes.extend([0xbf, table_addr & 0xff, (table_addr >> 8) & 0xff, (table_addr >> 16) & 0xff])
+        # BNE .is_imp (offset 0x12)
+        subroutine_bytes.extend([0xd0, 0x12])
+
+        # .not_imp:
+        # PLX (0xFA)
+        subroutine_bytes.append(0xfa)
+        # LDA $81A7 (0xAD, 0xA7, 0x81)
+        subroutine_bytes.extend([0xad, 0xa7, 0x81])
+        # TAY (0xA8)
+        subroutine_bytes.append(0xa8)
+        # LDA #$00 (0xA9, 0x00)
+        subroutine_bytes.extend([0xa9, 0x00])
+        # RTL (0x6B)
+        subroutine_bytes.append(0x6b)
+
+        # .not_imp_16:
+        # SEP #$20 (0xE2, 0x20)
+        subroutine_bytes.extend([0xe2, 0x20])
+        # PLX (0xFA)
+        subroutine_bytes.append(0xfa)
+        # LDA $81A7 (0xAD, 0xA7, 0x81)
+        subroutine_bytes.extend([0xad, 0xa7, 0x81])
+        # TAY (0xA8)
+        subroutine_bytes.append(0xa8)
+        # LDA #$00 (0xA9, 0x00)
+        subroutine_bytes.extend([0xa9, 0x00])
+        # RTL (0x6B)
+        subroutine_bytes.append(0x6b)
+
+        # .is_imp:
+        # LDA $81A7 (0xAD, 0xA7, 0x81)
+        subroutine_bytes.extend([0xad, 0xa7, 0x81])
+        # ASL A (0x0A)
+        subroutine_bytes.append(0x0a)
+        # TAX (0xAA)
+        subroutine_bytes.append(0xaa)
+        # REP #$20 (0xC2, 0x20)
+        subroutine_bytes.extend([0xc2, 0x20])
+        # LDA #$0000 (0xA9, 0x00, 0x00)
+        subroutine_bytes.extend([0xa9, 0x00, 0x00])
+        # STA $812F,X (0x9D, 0x2F, 0x81)
+        subroutine_bytes.extend([0x9d, 0x2f, 0x81])
+        # SEP #$20 (0xE2, 0x20)
+        subroutine_bytes.extend([0xe2, 0x20])
+
+        # PLX (0xFA)
+        subroutine_bytes.append(0xfa)
+        # LDA $81A7 (0xAD, 0xA7, 0x81)
+        subroutine_bytes.extend([0xad, 0xa7, 0x81])
+        # TAY (0xA8)
+        subroutine_bytes.append(0xa8)
+        # LDA #$01 (0xA9, 0x01)
+        subroutine_bytes.extend([0xa9, 0x01])
+        # RTL (0x6B)
+        subroutine_bytes.append(0x6b)
+
+        subroutine_space.write(subroutine_bytes)
+
+        # 4. Patch the original graphics loader at ROM offset 0x01207B (Bank C1)
+        # We replace 9 bytes from 0x01207B to 0x012083 with:
+        # JSL check_imp_graphics (4 bytes)
+        # BEQ $09 (2 bytes)
+        # NOP (3 bytes)
+        patch_space = Reserve(0x01207b, 0x012083, "who's there imp graphics loader hook", asm.NOP())
+        
+        sub_addr = subroutine_space.start_address_snes
+        patch_bytes = [
+            0x22, sub_addr & 0xff, (sub_addr >> 8) & 0xff, (sub_addr >> 16) & 0xff, # JSL check_imp_graphics
+            0xf0, 0x09,                                                            # BEQ $09 (to 0x01208A)
+            0xea, 0xea, 0xea                                                       # NOPs
+        ]
+        patch_space.write(patch_bytes)
 
     def get_event_boss(self, original_boss_name):
         return self.packs.get_event_boss_replacement(original_boss_name)

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -410,8 +410,9 @@ class Enemies():
 
     def who_there_mod(self):
         for enemy in self.enemies:
-            if enemy.id in bosses.enemy_name:
-                enemy.name = "??????"
+            if enemy.id in bosses.enemy_name or enemy.id == 282: # 282 is Undead SrBehemoth
+                if enemy.id not in range(343, 352): # Exclude Final Battle Tiers (Short Arm -> Sleep)
+                    enemy.name = "??????"
         self.who_there_assembly()
 
     def who_there_assembly(self):
@@ -427,6 +428,13 @@ class Enemies():
         for enemy_id in bosses.enemy_name:
             if 0 <= enemy_id < 384:
                 boss_table_bytes[enemy_id] = 1
+        
+        # Include SrBehemoth (Undead) Phase 2
+        boss_table_bytes[282] = 1
+        
+        # Exclude Final Battle Tiers
+        for excluded_id in range(343, 352):
+            boss_table_bytes[excluded_id] = 0
         
         boss_table_space = Allocate(Bank.F0, 384, "who's there boss table")
         boss_table_space.write(boss_table_bytes)

--- a/data/enemy_formations.py
+++ b/data/enemy_formations.py
@@ -179,6 +179,64 @@ class EnemyFormations():
         if self.args.random_encounters_chupon:
             self.add_chupon()
 
+        if self.args.oops is not None:
+            self.oops_mod()
+
+    def oops_mod(self):
+        boss_enemy_ids = set()
+        import data.bosses as bosses
+        boss_enemy_ids.update(bosses.normal_enemy_name.keys())
+        boss_enemy_ids.update(bosses.dragon_enemy_name.keys())
+        boss_enemy_ids.update(bosses.statue_enemy_name.keys())
+        boss_enemy_ids.update(bosses.final_battle_enemy_name.keys())
+
+        # The user-selected target boss ID
+        target_boss_id = self.args.oops
+
+        # Find the original formation ID of the chosen boss to get its native mold
+        original_formation_id = None
+        boss_name = None
+        for enemy_dict in [bosses.normal_enemy_name, bosses.dragon_enemy_name, bosses.statue_enemy_name, bosses.final_battle_enemy_name]:
+            if target_boss_id in enemy_dict:
+                boss_name = enemy_dict[target_boss_id]
+                break
+
+        if boss_name is not None:
+            for formation_dict in [bosses.normal_formation_name, bosses.dragon_formation_name, bosses.statue_formation_name, bosses.final_battle_formation_name]:
+                for fid, name in formation_dict.items():
+                    if name == boss_name:
+                        original_formation_id = fid
+                        break
+                if original_formation_id is not None:
+                    break
+
+        target_mold = None
+        if original_formation_id is not None:
+            target_mold = self.formations[original_formation_id].mold
+
+        for formation in self.formations:
+            has_boss = False
+            for enemy_index in range(formation.ENEMY_CAPACITY):
+                if formation.enemy_slots & (1 << enemy_index):
+                    if formation.enemy_ids[enemy_index] in boss_enemy_ids:
+                        has_boss = True
+                        break
+
+            if has_boss:
+                # Set only the first slot (slot 0) as active to prevent multi-boss VRAM overlays
+                formation.enemy_slots = 1
+
+                # Set slot 0's enemy ID to the target boss ID
+                formation.enemy_ids[0] = target_boss_id
+
+                # Center the single boss perfectly on screen (y = 5, x = 6)
+                formation.enemy_y_positions[0] = 5
+                formation.enemy_x_positions[0] = 6
+
+                # Apply the native mold for correct VRAM layout & rendering
+                if target_mold is not None:
+                    formation.mold = target_mold
+
     def print_scripts(self):
         for formation_index, formation in enumerate(self.formations):
             if formation.enable_event_script:

--- a/llms.md
+++ b/llms.md
@@ -1,0 +1,185 @@
+# LLM Developer Guide for Final Fantasy VI Worlds Collide
+
+This guide is designed for LLMs (such as Claude, GPT-4, Cursor, Gemini, Copilot) to understand the codebase structure, coding paradigms, core abstractions, and constraints of the Final Fantasy VI Worlds Collide randomizer project.
+
+> [!IMPORTANT]
+> **SELF-UPDATE MANDATE**: If any changes you make to the codebase during your work affect existing patterns, add new modules, change core APIs, or introduce new paradigms, you **MUST** update this file (`llms.md`) and `agents.md` as part of your changes to keep future AI agents correctly instructed.
+
+---
+
+## 1. Repository Blueprint
+
+The repository is modular and structured as follows:
+
+- **Root Directory**:
+  - [wc.py](file:///c:/Projects/wrjones104_WorldsCollide/wc.py): Central entry point. Orchestrates memory loading, parsing, modding, and writing.
+  - [seed.py](file:///c:/Projects/wrjones104_WorldsCollide/seed.py): Manages random number generation and seeding based on seed strings and flags.
+  - [sprite_hash.py](file:///c:/Projects/wrjones104_WorldsCollide/sprite_hash.py): Generates validation hashes based on settings and versions.
+- [args/](file:///c:/Projects/wrjones104_WorldsCollide/args): Flag and argument parsing. Every gameplay subsystem has a corresponding file here (e.g. `items.py`, `bosses.py`, `scaling.py`).
+- [memory/](file:///c:/Projects/wrjones104_WorldsCollide/memory): Core ROM memory abstractions. Manages memory range reservations, heap allocations, and bank writing.
+- [data/](file:///c:/Projects/wrjones104_WorldsCollide/data): Data modeling representing ROM records (characters, items, spells, shops, bosses). Parses bytes into objects, modifies them, and writes them back.
+- [instruction/](file:///c:/Projects/wrjones104_WorldsCollide/instruction):
+  - [asm.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/asm.py): Python wrappers for 65816 CPU assembly instructions.
+  - [field/instructions.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/field/instructions.py): Python classes for SNES map event script bytecodes.
+  - [field/custom.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/field/custom.py): Dynamically generated assembly-level custom event commands.
+- [event/](file:///c:/Projects/wrjones104_WorldsCollide/event): Game event logic. Each key quest/location has its own script (e.g. `airship.py`, `daryl_tomb.py`).
+- [battle/](file:///c:/Projects/wrjones104_WorldsCollide/battle): Battle logic, level scaling math, and multipliers.
+- [bug_fixes/](file:///c:/Projects/wrjones104_WorldsCollide/bug_fixes): Assembly-level bug fixes for the original game engine (e.g. Magic Evade bug).
+- [settings/](file:///c:/Projects/wrjones104_WorldsCollide/settings): Handles specific gameplay patches (e.g. speed-up/sprint mechanics, permadeath).
+- [utils/](file:///c:/Projects/wrjones104_WorldsCollide/utils): Helper functions for compression, random weightings, and lists.
+
+---
+
+## 2. Dynamic Option Processing (`args/`)
+
+All CLI options must be declared inside a module in `args/` and registered in [arguments.py](file:///c:/Projects/wrjones104_WorldsCollide/args/arguments.py).
+
+### How to Add a New Option
+Every module in `args/` (e.g., `args/misc.py`) must implement three key hook functions:
+
+1. `parse(parser)`: Register command-line arguments using standard `argparse` options.
+2. `process(args)`: Validate options and assign computed properties to the `args` object.
+3. `flags(args)`: Return the string flags corresponding to the active setting (crucial for seed RNG hash consistency).
+
+#### Example Module Pattern:
+```python
+# args/my_new_subsystem.py
+def parse(parser):
+    group = parser.add_argument_group("My Subsystem Settings")
+    group.add_argument("-mns", "--my-new-setting", action="store_true", help="Enable awesome new feature")
+
+def process(args):
+    # args is the global Arguments object
+    if args.my_new_setting:
+        # Perform computation or set internal flags
+        args.calculated_setting_value = 42
+
+def flags(args):
+    # Return string representation of settings for the seed generator
+    if args.my_new_setting:
+        return " -mns"
+    return ""
+```
+
+---
+
+## 3. ROM Space & Allocation Abstractions (`memory/`)
+
+Worlds Collide manages ROM modifications through the `Space` class in [memory/space.py](file:///c:/Projects/wrjones104_WorldsCollide/memory/space.py). **Never** write bytes directly to raw offsets manually.
+
+### Core Functions:
+- `Reserve(start_address, end_address, description, clear_value = None)`: Claims a static block of the original ROM. Useful for overwriting/hooking vanilla code.
+- `Allocate(bank, size, description, clear_value = None)`: Dynamically allocates an unused chunk of the specified size in a designated SNES bank (e.g. `Bank.C0`, `Bank.C4`, `Bank.F0`).
+- `Write(destination, data, description)`: Wraps `Reserve` or `Allocate` depending on whether `destination` is a bank or an address, flatly writing the instruction array.
+- `Read(start_address, end_address)`: Extracts a list of raw bytes from the ROM.
+
+> [!CAUTION]
+> **Space Conflicts**: The `Space` framework asserts that no two spaces overlap. Overlapping address reservations will raise a `RuntimeError` immediately upon randomizer execution. Always use `Allocate` when writing new subroutines to let the memory manager handle addresses safely.
+
+---
+
+## 4. 65816 Assembly Engine (`instruction/asm.py`)
+
+When modifying the game engine's assembly, use the instruction classes defined in [instruction/asm.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/asm.py) rather than raw bytes or custom compiler scripts.
+
+### Basic Assembly Example:
+```python
+import instruction.asm as asm
+from memory.space import Bank, Write
+
+src = [
+    asm.A8(),                   # Set 8-bit accumulator register mode
+    asm.LDA(0x1F60, asm.ABS),   # Load byte from RAM address $1F60
+    asm.XOR(0xFF, asm.IMM8),    # Bitwise XOR with $FF
+    asm.STA(0x1F60, asm.ABS),   # Store byte back to RAM address $1F60
+    asm.RTS(),                  # Return from subroutine
+]
+
+# Dynamically allocate this subroutine in Bank C0
+space = Write(Bank.C0, src, "my custom memory toggle routine")
+subroutine_address = space.start_address
+```
+
+### Register Modes & Width Modifiers:
+- `A8()`, `XY8()`, `AXY8()`: Sets register sizes to 8-bit.
+- `A16()`, `XY16()`, `AXY16()`: Sets register sizes to 16-bit.
+- Always match the operand widths in instruction wrappers (`asm.IMM8` vs `asm.IMM16`, `asm.ABS` vs `asm.LNG_X`).
+- Use labels inside source lists for branches to avoid hardcoded byte counts:
+  ```python
+  src = [
+      asm.LDA(0x0200, asm.ABS),
+      asm.BNE("SKIP_ACTION"),  # Branch to label string
+      asm.INC(),
+      "SKIP_ACTION",            # Label declaration
+      asm.RTS(),
+  ]
+  ```
+
+---
+
+## 5. Event and Custom Opcode Scripting
+
+Worlds Collide handles quest and dialogue scripting using SNES map event bytecodes.
+
+### 5.1 Standard Field Scripting (`instruction/field/instructions.py`)
+Field scripts represent in-game engine scripts. Standard instructions mapped to Python classes include:
+- `SetEventBit(bit)`, `ClearEventBit(bit)`
+- `BranchIfEventBitSet(bit, destination)`, `BranchIfEventBitClear(bit, destination)`
+- `Dialog(dialog_id)`, `AddItem(item_id)`, `AddEsper(esper_id)`
+- `LoadMap(map_id, direction, default_music, x, y)`, `FadeLoadMap(...)`
+
+> [!WARNING]
+> Every script path **MUST** terminate with `Return()` or `End()` (or transfer control permanently). Failing to terminate a script path results in the SNES engine executing subsequent memory bytes as garbage instructions, crashing the emulator.
+
+### 5.2 Dynamic Custom Field Opcodes (`instruction/field/custom.py`)
+If a script feature requires complex logic not supported by vanilla FF6 event scripting, Worlds Collide compiles custom assembly, registers it as a new event bytecode, and binds it to an unused opcode in the SNES event interpreter:
+
+```python
+# instruction/field/custom.py
+class RecruitCharacter(_Instruction):
+    def __init__(self, character):
+        recruit_character_function = START_ADDRESS_SNES + c0.recruit_character
+        src = [
+            asm.JSL(recruit_character_function),
+            asm.LDA(0x02, asm.IMM8),        # 2-byte event command size (opcode + arg)
+            asm.JMP(0x9b5c, asm.ABS),       # Return control to field interpreter
+        ]
+        space = Write(Bank.C0, src, "custom recruit_character command")
+        address = space.start_address
+
+        # Register the bytecode $76 to point to our newly compiled custom assembly routine
+        opcode = 0x76
+        _set_opcode_address(opcode, address)
+
+        # Initialize base bytecode instruction
+        super().__init__(opcode, character)
+```
+
+---
+
+## 6. Dynamic Import Guardrails
+
+To prevent circular dependency locks (since subsystems like `args`, `data`, `event`, and `instruction` rely on each other), Worlds Collide frequently imports files inside local methods rather than globally at the top of the file:
+
+```python
+# Preferred pattern in event/ or data/ modules
+def mod(self):
+    from log import section  # Local import prevents startup circular reference crashes
+    import random
+    ...
+```
+
+Keep imports localized to functions unless you are confident the module is a leaf-node helper.
+
+---
+
+## 7. Test Data Isolation
+
+All generated test data, output ROMs, log text files, and metadata manifests generated during manual/automated testing **MUST** be placed in a dedicated `tests/` directory at the root of the workspace.
+
+- **Rule**: Never save output test artifacts (e.g., test ROMs or generated log files) directly to the workspace root.
+- **Directory**: `tests/`
+- **Output Paths**: Ensure files are explicitly targeted to the isolated subdirectory, for example:
+  - Output test ROM: `tests/test_output.smc`
+  - Output test Log: `tests/test_output.txt`
+  - Manifest file: `tests/test_manifest.json`

--- a/llms.md
+++ b/llms.md
@@ -12,27 +12,27 @@ This guide is designed for LLMs (such as Claude, GPT-4, Cursor, Gemini, Copilot)
 The repository is modular and structured as follows:
 
 - **Root Directory**:
-  - [wc.py](file:///c:/Projects/wrjones104_WorldsCollide/wc.py): Central entry point. Orchestrates memory loading, parsing, modding, and writing.
-  - [seed.py](file:///c:/Projects/wrjones104_WorldsCollide/seed.py): Manages random number generation and seeding based on seed strings and flags.
-  - [sprite_hash.py](file:///c:/Projects/wrjones104_WorldsCollide/sprite_hash.py): Generates validation hashes based on settings and versions.
-- [args/](file:///c:/Projects/wrjones104_WorldsCollide/args): Flag and argument parsing. Every gameplay subsystem has a corresponding file here (e.g. `items.py`, `bosses.py`, `scaling.py`).
-- [memory/](file:///c:/Projects/wrjones104_WorldsCollide/memory): Core ROM memory abstractions. Manages memory range reservations, heap allocations, and bank writing.
-- [data/](file:///c:/Projects/wrjones104_WorldsCollide/data): Data modeling representing ROM records (characters, items, spells, shops, bosses). Parses bytes into objects, modifies them, and writes them back.
-- [instruction/](file:///c:/Projects/wrjones104_WorldsCollide/instruction):
-  - [asm.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/asm.py): Python wrappers for 65816 CPU assembly instructions.
-  - [field/instructions.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/field/instructions.py): Python classes for SNES map event script bytecodes.
-  - [field/custom.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/field/custom.py): Dynamically generated assembly-level custom event commands.
-- [event/](file:///c:/Projects/wrjones104_WorldsCollide/event): Game event logic. Each key quest/location has its own script (e.g. `airship.py`, `daryl_tomb.py`).
-- [battle/](file:///c:/Projects/wrjones104_WorldsCollide/battle): Battle logic, level scaling math, and multipliers.
-- [bug_fixes/](file:///c:/Projects/wrjones104_WorldsCollide/bug_fixes): Assembly-level bug fixes for the original game engine (e.g. Magic Evade bug).
-- [settings/](file:///c:/Projects/wrjones104_WorldsCollide/settings): Handles specific gameplay patches (e.g. speed-up/sprint mechanics, permadeath).
-- [utils/](file:///c:/Projects/wrjones104_WorldsCollide/utils): Helper functions for compression, random weightings, and lists.
+  - [wc.py](wc.py): Central entry point. Orchestrates memory loading, parsing, modding, and writing.
+  - [seed.py](seed.py): Manages random number generation and seeding based on seed strings and flags.
+  - [sprite_hash.py](sprite_hash.py): Generates validation hashes based on settings and versions.
+- [args/](args/): Flag and argument parsing. Every gameplay subsystem has a corresponding file here (e.g. `items.py`, `bosses.py`, `scaling.py`).
+- [memory/](memory/): Core ROM memory abstractions. Manages memory range reservations, heap allocations, and bank writing.
+- [data/](data/): Data modeling representing ROM records (characters, items, spells, shops, bosses). Parses bytes into objects, modifies them, and writes them back.
+- [instruction/](instruction/):
+  - [asm.py](instruction/asm.py): Python wrappers for 65816 CPU assembly instructions.
+  - [field/instructions.py](instruction/field/instructions.py): Python classes for SNES map event script bytecodes.
+  - [field/custom.py](instruction/field/custom.py): Dynamically generated assembly-level custom event commands.
+- [event/](event/): Game event logic. Each key quest/location has its own script (e.g. `airship.py`, `daryl_tomb.py`).
+- [battle/](battle/): Battle logic, level scaling math, and multipliers.
+- [bug_fixes/](bug_fixes/): Assembly-level bug fixes for the original game engine (e.g. Magic Evade bug).
+- [settings/](settings/): Handles specific gameplay patches (e.g. speed-up/sprint mechanics, permadeath).
+- [utils/](utils/): Helper functions for compression, random weightings, and lists.
 
 ---
 
 ## 2. Dynamic Option Processing (`args/`)
 
-All CLI options must be declared inside a module in `args/` and registered in [arguments.py](file:///c:/Projects/wrjones104_WorldsCollide/args/arguments.py).
+All CLI options must be declared inside a module in `args/` and registered in [arguments.py](args/arguments.py).
 
 ### How to Add a New Option
 Every module in `args/` (e.g., `args/misc.py`) must implement three key hook functions:
@@ -65,7 +65,7 @@ def flags(args):
 
 ## 3. ROM Space & Allocation Abstractions (`memory/`)
 
-Worlds Collide manages ROM modifications through the `Space` class in [memory/space.py](file:///c:/Projects/wrjones104_WorldsCollide/memory/space.py). **Never** write bytes directly to raw offsets manually.
+Worlds Collide manages ROM modifications through the `Space` class in [memory/space.py](memory/space.py). **Never** write bytes directly to raw offsets manually.
 
 ### Core Functions:
 - `Reserve(start_address, end_address, description, clear_value = None)`: Claims a static block of the original ROM. Useful for overwriting/hooking vanilla code.
@@ -80,7 +80,7 @@ Worlds Collide manages ROM modifications through the `Space` class in [memory/sp
 
 ## 4. 65816 Assembly Engine (`instruction/asm.py`)
 
-When modifying the game engine's assembly, use the instruction classes defined in [instruction/asm.py](file:///c:/Projects/wrjones104_WorldsCollide/instruction/asm.py) rather than raw bytes or custom compiler scripts.
+When modifying the game engine's assembly, use the instruction classes defined in [instruction/asm.py](instruction/asm.py) rather than raw bytes or custom compiler scripts.
 
 ### Basic Assembly Example:
 ```python

--- a/llms.md
+++ b/llms.md
@@ -183,3 +183,13 @@ All generated test data, output ROMs, log text files, and metadata manifests gen
   - Output test ROM: `tests/test_output.smc`
   - Output test Log: `tests/test_output.txt`
   - Manifest file: `tests/test_manifest.json`
+
+---
+
+## 8. Cosmetic Flag Modifications & WRAM / Sprite Hooks
+
+When implementing visual-only overrides (such as "Who's There?" `-who` / `--who-there` mode):
+- **Name Obfuscation**: Modify name fields in `data/enemies.py` directly. The data layer will serialize and write the modified text bytes to the ROM during serialization.
+- **Visual Sprite Loader Hooking**: Patch the graphics loader logic at ROM offset `0x01207B` (Bank `C1`) using `Reserve` to intercept the check for monster status effects (e.g. WRAM Imp Graphics flags `$62C2,Y` indexed by slot ID). A custom assembly routine in Bank `F0` (via `Allocate`) evaluates conditions (e.g., `-who` flag status and looking up the active monster's ID directly from WRAM `$812F,Y` (indexed by slot * 2) after clearing the Accumulator's high byte using `TDC` (`0x7B`) immediately after `PHX` to avoid index register pollution, against a 384-byte `boss_table` of boss IDs using 24-bit absolute opcodes `0xAF`/`0xBF`). The subroutine redirects rendering to the Imp sprite dynamically without applying the actual status, while strictly preserving Index Register X (`PHX`/`PLX`) to ensure standard graphics rendering for all other enemies remains perfectly intact.
+- **Python 3.14 Compatibility**: When selecting random items/espers from a `set` pool (such as `self.available_espers` in `data/espers.py`), never pass the `set` directly to `random.sample()`, as Python 3.9+ deprecates and Python 3.11+ (including Python 3.14) throws `TypeError`. Instead, convert the set to a tuple: `random.sample(tuple(set_pool), 1)[0]`. This satisfies Python's sequence checks while maintaining 100% identical random state consumption and seed choice sequence compatibility with all older Python versions.
+- **Character Gating & Reward Types**: In `event/event_reward.py`, `single_possible_type(self)` checks if a reward slot allows only a single type. Because Python's `Flag` allows checking membership for compound flag combinations (`RewardType.CHARACTER | RewardType.ESPER in RewardType` evaluates to `True`), checking `possible_types in RewardType` was a major bug that caused compound slots to be treated as single-type slots. This lead to gating deadlocks (`AssertionError` in `choose_reward`) under specific seed/flag configurations. The fix is to explicitly check against exact single-member flags: `return self.possible_types in (RewardType.CHARACTER, RewardType.ESPER, RewardType.ITEM)`.


### PR DESCRIPTION
# Feature: Who's There?!?
## Summary
Implements the -who flag, which replaces all boss sprites with the standard Imp sprite and replaces their display names with ??????.

## Technical Implementation
1. Name Obfuscation
* Iterates through the bosses.enemy_name index mapping.
* Replaces boss name strings in the ROM with ?????? (hex 0xBF).
2. Assembly Graphics Hook
* Injects a custom 65816 assembly subroutine into Bank C0.
* Patches the battle graphics loading routine at ROM offset 0x01207B (Bank C1).
** Logic: The routine reads the 16-bit monster ID from WRAM $2001,X (indexed by slot) and compares it against a 384-byte boss_table in Bank F0. If a match is found, it forces the graphics pointer to the Imp index ( #$0816).
3. VRAM/Tilemap Corruption Fix
* Issue: Large or multi-part bosses (e.g., Tentacles, Whelk) use custom tilemap dimensions. Forcing the small Imp sprite into these large maps causes PPU read errors and VRAM corruption.
* Solution: Within the .is_imp branch, the routine overwrites the active graphics index array ( $812F,X) with 0 (Guard ID). This forces the dimension calculator ( JSR $202F) to assign standard 32x32 properties, ensuring multi-part components render as individual, stable Imps.
## Exceptions & Edge Cases
### Included: 
SrBehemoth (ID 282) was manually added to the lookup table to ensure both phases are transformed. Final Kefka (ID 298) is also transformed.
### Excluded:
Final Battle Tiers (IDs 343–351) to preserve end-game aesthetics.
Phantom Train (rendered as a background layer rather than a sprite object).