### PR TITLE
Feature: add shops expensive restorative items flag (-seri)

### DIFF
--- a/args/shops.py
+++ b/args/shops.py
@@ -46,7 +46,9 @@ def parse(parser):
                        help = "Super Balls not sold in shops")
     shops.add_argument("-sesb", "--shops-expensive-super-balls", action = "store_true",
                        help = "Super Balls base price increase")
-    
+
+    shops.add_argument("-seri", "--shops-expensive-restorative-items", action="store_true",
+                       help = "Increase base price of most restorative items (Potions, Ethers, Tents, etc.)")
 
     shops.add_argument("-snee", "--shops-no-exp-eggs", action = "store_true",
                        help = "Exp. Eggs not sold in shops")
@@ -100,6 +102,9 @@ def flags(args):
         flags += " -snsb"
     if args.shops_expensive_super_balls:
         flags += " -sesb"
+
+    if args.shops_expensive_restorative_items:
+        flags += " -seri"
 
     if args.shops_no_exp_eggs:
         flags += " -snee"
@@ -157,6 +162,7 @@ def options(args):
         ("No Elemental Shields", args.shops_no_elemental_shields, "shops_no_elemental_shields"),
         ("No Super Balls", args.shops_no_super_balls, "shops_no_super_balls"),
         ("Expensive Balls", args.shops_expensive_super_balls, "shops_expensive_super_balls"),
+        ("Expensive Restoratives", args.shops_expensive_restorative_items, "shops_expensive_restorative_items"),
         ("No Exp. Eggs", args.shops_no_exp_eggs, "shops_no_exp_eggs"),
         ("No Illuminas", args.shops_no_illuminas, "shops_no_illuminas"),
     ])

--- a/data/items.py
+++ b/data/items.py
@@ -266,6 +266,13 @@ class Items():
         if self.args.no_priceless_items:
             self.assign_values()
 
+        # Item price modifications: apply price randomization first
+        if self.args.shop_prices_random_value:
+            self.random_prices_value()
+        elif self.args.shop_prices_random_percent:
+            self.random_prices_percent()
+
+        # Item price modifications: apply item price multipliers after
         if self.args.shops_expensive_breakable_rods:
             self.expensive_breakable_rods()
 
@@ -274,11 +281,6 @@ class Items():
 
         if self.args.shops_expensive_restorative_items:
             self.expensive_restorative_items()
-
-        if self.args.shop_prices_random_value:
-            self.random_prices_value()
-        elif self.args.shop_prices_random_percent:
-            self.random_prices_percent()
 
         for a_spell_id in self.args.remove_learnable_spell_ids:
             self.remove_learnable_spell(a_spell_id)

--- a/data/items.py
+++ b/data/items.py
@@ -198,6 +198,17 @@ class Items():
     def expensive_super_balls(self):
         self.items[name_id["Super Ball"]].scale_price(2)
 
+    def expensive_restorative_items(self):
+        restoratives = {
+            3: ["Fenix Down", "Tonic", "Dried Meat", "Potion", "Tincture", "Ether",
+                "Sleeping Bag", "Tent", "Remedy", "Antidote", "Eyedrop",
+                "Echo Screen", "Soft", "Revivify", "Green Cherry"],
+            2: ["X-Potion", "X-Ether"]
+        }
+        for factor, names in restoratives.items():
+            for name in names:
+                self.items[name_id[name]].scale_price(factor)
+
     def assign_values(self):
         from data.item_custom_values import custom_values
         for item in self.items:
@@ -260,6 +271,9 @@ class Items():
 
         if self.args.shops_expensive_super_balls:
             self.expensive_super_balls()
+
+        if self.args.shops_expensive_restorative_items:
+            self.expensive_restorative_items()
 
         if self.args.shop_prices_random_value:
             self.random_prices_value()


### PR DESCRIPTION
Adds a flag -seri (--shops-expensive-restorative-items) that increases the base price of most restorative items. Basic restoratives are increased by a factor 3x by default; high restoratives (X-Potion, X-Ether) are increased by 2x. Elixirs and Megalixirs are not increased (as these are often sold to generate cash). This is intended to add challenge to the resource management by making what restoratives to purchase more of a decision.

This flag should be compatible with all other shop flags.

If there is interest we could add a scalar on this (e.g. -seri 5 for 5x increase in default cost and 3.33x increase in high restoratives). But that can be left for future work.

Resubmitted 6/4/26 to provide a clean patch to dev branch (1.4.4d).