### PR TITLE
Feature/shops limited inventory playtesting update

### DIFF
--- a/data/shops.py
+++ b/data/shops.py
@@ -285,7 +285,7 @@ class Shops():
                 return random.randint(1, 2)
             return random.randint(1, 4)
 
-        # Basic healing items: 1-5 for Fenix Down, 2-6 for everything else
+        # Basic healing items: 1-4 for Fenix Down, 2-6 for everything else
         if item_id in self.BASIC_HEALING:
             if item_id == name_id["Fenix Down"]:
                 return random.randint(1, 4)

--- a/data/shops.py
+++ b/data/shops.py
@@ -281,7 +281,7 @@ class Shops():
         if item_id in RELICS:
             if item_id in self.SPECIAL_RELICS:
                 return 1
-            elif item_id in (name_id["Earrings"]):
+            elif item_id == name_id["Earrings"]:
                 return random.randint(1,2)
             return random.randint(1, 4)
 

--- a/data/shops.py
+++ b/data/shops.py
@@ -234,6 +234,7 @@ class Shops():
         name_id["Dragon Horn"], name_id["Gem Box"], name_id["Merit Award"],
         name_id["Exp. Egg"], name_id["Marvel Shoes"], name_id["Ribbon"],
         name_id["Genji Glove"], name_id["Gauntlet"], name_id["Moogle Charm"],
+        name_id["Atlas Armlet"], name_id["DragoonBoots"],
     }
 
     # Basic healing items: larger packs (3-10)
@@ -276,22 +277,24 @@ class Shops():
             else:
                 return 1
 
-        # Relics: 1-4, except special relics which are singles
+        # Relics: 1-4, except special relics (1) and earrings (1-2)
         if item_id in RELICS:
             if item_id in self.SPECIAL_RELICS:
                 return 1
+            elif item_id in (name_id["Earrings"]):
+                return random.randint(1,2)
             return random.randint(1, 4)
 
-        # Basic healing items: 1-5 for Fenix Down, 3-8 for everything else
+        # Basic healing items: 1-5 for Fenix Down, 2-6 for everything else
         if item_id in self.BASIC_HEALING:
             if item_id == name_id["Fenix Down"]:
-                return random.randint(1, 5)
+                return random.randint(1, 4)
             else:
-                return random.randint(3, 8)
+                return random.randint(2, 6)
 
-        # High healing items: 1-3
+        # High healing items: 1-2
         if item_id in self.HIGH_HEALING:
-            return random.randint(1, 3)
+            return random.randint(1, 2)
 
         # Elixir, Megalixir: singles
         if item_id in (name_id["Elixir"], name_id["Megalixir"]):

--- a/data/shops.py
+++ b/data/shops.py
@@ -282,7 +282,7 @@ class Shops():
             if item_id in self.SPECIAL_RELICS:
                 return 1
             elif item_id == name_id["Earrings"]:
-                return random.randint(1,2)
+                return random.randint(1, 2)
             return random.randint(1, 4)
 
         # Basic healing items: 1-5 for Fenix Down, 2-6 for everything else

--- a/event/free_heals.py
+++ b/event/free_heals.py
@@ -118,6 +118,11 @@ def modify_inn_costs(maps, rom, dialogs, args):
     # New: Display price, take GP, then jump to original movement code at 0xCAF659
     RETURNERS_DIALOG_ID = 0x111
     RETURNERS_ORIGINAL_YES_CODE = 0xCAF659
+    # Vanilla "You don't have enough money." dialog shown by paid inns on the
+    # insufficient-funds path (also reused by the airship and phantom train
+    # heals under -nfh). Already contains the right text in the base ROM, so no
+    # set_text is needed.
+    NOT_ENOUGH_GP_DIALOG_ID = 2748
 
     returners_price = min(RETURNERS_HIDEOUT_INN_PRICE * INN_COST_MULTIPLIER, field.RemoveGP.MAX)
 
@@ -135,6 +140,7 @@ def modify_inn_costs(maps, rom, dialogs, args):
 
         "RETURNERS_NO_MONEY",
         field.ClearEventBit(event_bit.NOT_ENOUGH_GP),
+        field.Dialog(NOT_ENOUGH_GP_DIALOG_ID),
         "RETURNERS_NO",
         field.Return(),
     ]

--- a/event/free_heals.py
+++ b/event/free_heals.py
@@ -118,11 +118,6 @@ def modify_inn_costs(maps, rom, dialogs, args):
     # New: Display price, take GP, then jump to original movement code at 0xCAF659
     RETURNERS_DIALOG_ID = 0x111
     RETURNERS_ORIGINAL_YES_CODE = 0xCAF659
-    # Vanilla "You don't have enough money." dialog shown by paid inns on the
-    # insufficient-funds path (also reused by the airship and phantom train
-    # heals under -nfh). Already contains the right text in the base ROM, so no
-    # set_text is needed.
-    NOT_ENOUGH_GP_DIALOG_ID = 2748
 
     returners_price = min(RETURNERS_HIDEOUT_INN_PRICE * INN_COST_MULTIPLIER, field.RemoveGP.MAX)
 
@@ -140,7 +135,6 @@ def modify_inn_costs(maps, rom, dialogs, args):
 
         "RETURNERS_NO_MONEY",
         field.ClearEventBit(event_bit.NOT_ENOUGH_GP),
-        field.Dialog(NOT_ENOUGH_GP_DIALOG_ID),
         "RETURNERS_NO",
         field.Return(),
     ]
@@ -186,7 +180,6 @@ def modify_inn_costs(maps, rom, dialogs, args):
 
         "FIGARO_NO_MONEY",
         field.ClearEventBit(event_bit.NOT_ENOUGH_GP),
-        field.Dialog(NOT_ENOUGH_GP_DIALOG_ID),
         "FIGARO_RETURN",
         field.Return(),
     ]

--- a/event/free_heals.py
+++ b/event/free_heals.py
@@ -186,6 +186,7 @@ def modify_inn_costs(maps, rom, dialogs, args):
 
         "FIGARO_NO_MONEY",
         field.ClearEventBit(event_bit.NOT_ENOUGH_GP),
+        field.Dialog(NOT_ENOUGH_GP_DIALOG_ID),
         "FIGARO_RETURN",
         field.Return(),
     ]


### PR DESCRIPTION
Edited shop inventory ranges based on playtesting, as follows:
- Atlas Armlet, Dragoon Boots were reduced to 1 with other "special" relics.
- Earrings: reduced from {1,4} to {1,2}.
- Fenix Down: reduced from {1,5} --> {1,4}
- Basic Healing: reduced from {2-8} --> {2,6}
- High Healing: reduced from {1,3} --> {1,2}